### PR TITLE
Bump path upper bound

### DIFF
--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -180,7 +180,7 @@ test-suite tests
         filepath >=1.2 && <1.5,
         hspec >=2.0 && <3.0,
         fourmolu -any,
-        path >=0.6 && <0.8,
+        path >=0.6 && <0.9,
         path-io >=1.4.2 && <2.0,
         text >=0.2 && <1.3
 


### PR DESCRIPTION
Tested locally:
1. Add `path-0.8.0` to `extra-deps` in `stack.yaml`
2. Run `stack test`