### PR TITLE
do not revert Fourmolu magic comments to Ormolu form

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ source code must still be parseable even when the disabled regions are
 omitted. Because of that the magic comments cannot be placed arbitrarily,
 but rather must enclose independent top-level definitions.
 
-`{- ORMOLU_DISABLE -}` and `{- ORMOLU_ENABLE -}`, respectively, can be used to the same effect.
+`{- ORMOLU_DISABLE -}` and `{- ORMOLU_ENABLE -}`, respectively, can be used to the same effect,
+and the two styles of magic comments can be mixed.
 
 ## Current limitations
 

--- a/data/examples/other/disabling/mixed-styles-four-out.hs
+++ b/data/examples/other/disabling/mixed-styles-four-out.hs
@@ -1,0 +1,17 @@
+module Foo (foo, bar, baz, qux) where
+
+{- ORMOLU_DISABLE -}
+foo :: Char
+foo =  'a'
+{- FOURMOLU_ENABLE -}
+
+bar :: Char
+bar = 'b'
+
+{- FOURMOLU_DISABLE -}
+baz :: Char
+baz =  'c'
+{- ORMOLU_ENABLE -}
+
+qux :: Char
+qux = 'd'

--- a/data/examples/other/disabling/mixed-styles-out.hs
+++ b/data/examples/other/disabling/mixed-styles-out.hs
@@ -1,0 +1,17 @@
+module Foo (foo, bar, baz, qux) where
+
+{- ORMOLU_DISABLE -}
+foo :: Char
+foo =  'a'
+{- FOURMOLU_ENABLE -}
+
+bar :: Char
+bar = 'b'
+
+{- FOURMOLU_DISABLE -}
+baz :: Char
+baz =  'c'
+{- ORMOLU_ENABLE -}
+
+qux :: Char
+qux = 'd'

--- a/data/examples/other/disabling/mixed-styles.hs
+++ b/data/examples/other/disabling/mixed-styles.hs
@@ -1,0 +1,17 @@
+module Foo (foo, bar, baz, qux) where
+
+{- ORMOLU_DISABLE -}
+foo :: Char
+foo =  'a'
+{- FOURMOLU_ENABLE -}
+
+bar :: Char
+bar =  'b'
+
+{- FOURMOLU_DISABLE -}
+baz :: Char
+baz =  'c'
+{- ORMOLU_ENABLE -}
+
+qux :: Char
+qux =  'd'


### PR DESCRIPTION
Closes #70. 

After looking at the code I've decided **not** to add another option, and **not** to track which of the comments was used to disable the formatter. I just treat the two styles of comments as equivalent (e.g. after using `{- ORMOLU_DISABLE -}` we may use `{- FOURMOLU_ENABLE -}` to re-enable formatting), but I do not change the style of the comment used in the original file.

Adding an extra option just for this seemed weird. It's easy, but it adds much noise.
Tracking could be useful in some scenarios, but do we really need this?

This solution is simple, keeps Ormolu compatibility and is consistent with the current behavior.

However, if you think it's wrong this way, feel free to close the PR.