### PR TITLE
Make the 'Loaded config from' message debugging output

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -369,7 +369,7 @@ mkConfig path Opts {..} = do
   filePrinterOpts <-
     loadConfigFile path >>= \case
       ConfigLoaded f po -> do
-        hPutStrLn stderr $ "Loaded config from: " <> f
+        printDebug $ "Loaded config from: " <> f
         printDebug $ show po
         return $ Just po
       ConfigParseError f (_pos, err) -> do


### PR DESCRIPTION
What: 
Changes the "Loaded config from" message to only be printed alongside other debugging output

How:
Use `printDebug` instead of `hPutStrLn stderr` to print the message

Why:
1. Having clean output in the happy path makes editor integration somewhat easier. For example, using `shell-command-on-region` in emacs to format unsaved buffers causes emacs to insert the message from stderr into the file.
2. This is the only informational message in the application that is printed to `stderr` without debugging enabled. This change makes the behavior consistent with other message output.