### PR TITLE
Use trailing haddocks for record fields when using leading commas

### DIFF
--- a/data/examples/declaration/data/field-layout/record-four-out.hs
+++ b/data/examples/declaration/data/field-layout/record-four-out.hs
@@ -2,11 +2,11 @@ module Main where
 
 -- | Foo.
 data Foo = Foo
-    { -- | Something
-      foo :: Foo Int Int
-    , -- | Something else
-      bar ::
+    { foo :: Foo Int Int
+    -- ^ Something
+    , bar ::
         Bar
             Char
             Char
+    -- ^ Something else
     }

--- a/data/examples/declaration/data/record-four-out.hs
+++ b/data/examples/declaration/data/record-four-out.hs
@@ -2,22 +2,22 @@ module Main where
 
 -- | Something.
 data Foo = Foo
-    { -- | X
-      fooX :: Int
-    , -- | Y
-      fooY :: Int
-    , -- | BarBaz
-      fooBar, fooBaz :: NonEmpty (Identity Bool)
-    , -- | GagGog
-      fooGag
+    { fooX :: Int
+    -- ^ X
+    , fooY :: Int
+    -- ^ Y
+    , fooBar, fooBaz :: NonEmpty (Identity Bool)
+    -- ^ BarBaz
+    , fooGag
       , fooGog ::
         NonEmpty
             ( Indentity
                 Bool
             )
-    , -- | Huh!
-      fooFoo
+    -- ^ GagGog
+    , fooFoo
       , barBar ::
         Int
+    -- ^ Huh!
     }
     deriving (Eq, Show)

--- a/data/examples/declaration/data/record-multi-const-four-out.hs
+++ b/data/examples/declaration/data/record-multi-const-four-out.hs
@@ -3,15 +3,15 @@ module Main where
 -- | Something.
 data Foo
     = Foo
-        { -- | X
-          fooX :: Int
-        , -- | Y
-          fooY :: Int
+        { fooX :: Int
+        -- ^ X
+        , fooY :: Int
+        -- ^ Y
         }
     | Bar
-        { -- | X
-          barX :: Int
-        , -- | Y
-          barY :: Int
+        { barX :: Int
+        -- ^ X
+        , barY :: Int
+        -- ^ Y
         }
     deriving (Eq, Show)


### PR DESCRIPTION
This is inspired by (and lifts the core code from) #98.

Differences:
- It's rebased on to `master`.
- The comments are moved two spaces left. I think this looks better, but I'm happy to hear any dissenting opinions. This is the reason for the removal of the `sitcc` call in `Ormolu.Printer.Meat.Type`.
- There's no separate option. Instead we just follow `poCommaStyle`, and use trailing haddocks iff it's set to `Leading`. This removes the "Disallow this in combination with trailing comma style" concern (I'm not sure `optparse-applicative` provides a nice way to do that). And the old style is so ugly that I really don't see any reason why anyone would prefer it. It's just a relic of adapting Ormolu to leading commas in the simplest way possible.