### PR TITLE
Use trailing haddocks for constructors in datatype declarations

### DIFF
--- a/data/examples/declaration/data/fat-multiline-four-out.hs
+++ b/data/examples/declaration/data/fat-multiline-four-out.hs
@@ -2,11 +2,11 @@ module Main where
 
 -- | Something.
 data Foo
-    = -- | Foo
-      Foo
+    = Foo
+    -- ^ Foo
         Int
         Int
-    | -- | Bar
-      Bar
+    | Bar
+    -- ^ Bar
         Bool
         Bool

--- a/data/examples/declaration/data/field-layout/variants-four-out.hs
+++ b/data/examples/declaration/data/field-layout/variants-four-out.hs
@@ -2,9 +2,11 @@ module Main where
 
 -- | Foo.
 data Foo
-    = -- | Something
-      Foo Int Int
-    | -- | Something else
-      Bar
+    = Foo
+    -- ^ Something
+        Int
+        Int
+    | Bar
+    -- ^ Something else
         Char
         Char

--- a/data/examples/declaration/data/multiline-four-out.hs
+++ b/data/examples/declaration/data/multiline-four-out.hs
@@ -2,11 +2,12 @@ module Main where
 
 -- | Here we have 'Foo'.
 data Foo
-    = -- | One
-      Foo
-    | -- | Two
-      Bar Int
-    | -- | Three
-      Baz
+    = Foo
+    -- ^ One
+    | Bar
+    -- ^ Two
+        Int
+    | Baz
+    -- ^ Three
     deriving
         (Eq, Show)

--- a/data/examples/declaration/data/operators-four-out.hs
+++ b/data/examples/declaration/data/operators-four-out.hs
@@ -1,9 +1,11 @@
 data ErrorMessage' s
-    = -- | Show the text as is.
-      Text s
-    | -- | Pretty print the type.
-      -- @ShowType :: k -> ErrorMessage@
-      forall t. ShowType t
+    = Text
+    -- ^ Show the text as is.
+        s
+    | forall t. ShowType
+    -- ^ Pretty print the type.
+    -- @ShowType :: k -> ErrorMessage@
+        t
     | -- | Put two pieces of error message next
       -- to each other.
       ErrorMessage' s :<>: ErrorMessage' s

--- a/data/examples/declaration/data/partly-documented-four-out.hs
+++ b/data/examples/declaration/data/partly-documented-four-out.hs
@@ -1,5 +1,5 @@
 data Optimisation
     = PETransform
-    | -- | partial eval and associated transforms
-      GeneralisedNatHack
+    | GeneralisedNatHack
+    -- ^ partial eval and associated transforms
     deriving (Show, Eq, Generic)

--- a/data/examples/declaration/data/unnamed-field-comment-0-four-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-0-four-out.hs
@@ -1,6 +1,6 @@
 data Foo
-    = -- | Bar
-      Bar
+    = Bar
+    -- ^ Bar
         Field1
         -- ^ Field 1
         Field2

--- a/data/examples/declaration/data/with-weird-haddock-four-out.hs
+++ b/data/examples/declaration/data/with-weird-haddock-four-out.hs
@@ -1,4 +1,6 @@
 data PlusLevel' t
-    = -- | @n + ℓ@.
-      Plus Integer (LevelAtom' t)
+    = Plus
+    -- ^ @n + ℓ@.
+        Integer
+        (LevelAtom' t)
     deriving (Show, Data)


### PR DESCRIPTION
It is a bit unfortunate that this forces single-line layouts to multi-line when there's a haddock on the constructor. As far as I'm aware this sort of behaviour is unprecedented.

Perhaps the leading style like https://github.com/tweag/ormolu/issues/583#issuecomment-644043287 is the ideal. Although the fact that comments then appear before the `|` is arguably slightly confusing and may hamper readability. Also, as indicated in https://github.com/tweag/ormolu/issues/583#issuecomment-646550697 it means a significant refactor may be necessary. Perhaps if one of us put up a PR, we could get that merged upstream?

~~Though if we were to do that, we may also want to do the analogous thing for record fields, which means not merging~~. Actually there's then seemingly nowhere good to put the haddock for the first field when using leading commas - it can't go before the `{`.

This is a draft because:
- The implementation is messy.
- I haven't tackled operators.
- This should be put behind a flag to maintain close compatibility with Ormolu. Although I'd like it to be on by default.
- The `declaration/data/operators.hs` test is failing due to an idempotency issue with `forall` and multi-line layout.
  - All the other test failures are just due to the fact that this hasn't been put behind a flag.
- As above, I'm not totally sure it's the best approach.

Interested to hear everyone's thoughts.