### PR TITLE
Add option for spaceless '{-|'

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We share all bar one of Ormolu's goals:
 | `indent-wheres`      | `true`, `false` | `false` means save space by only half-indenting the `where` keyword |
 | `record-brace-space` | `true`, `false` | `rec {x = 1}` vs `rec{x = 1}` |
 | `respectful`         | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
-| `haddock-style`      | `multi-line`, `single-line` | Whether multiline haddocks should use `{-` or `--` |
+| `haddock-style`      | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `{-` or `--` |
 | `newlines-between-decls` | any integer | number of newlines between top-level declarations |
 | `fixities`           | A list of strings for defining fixities; see the "Language extensions, dependencies, and fixities" section below |
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We share all bar one of Ormolu's goals:
 | `indent-wheres`      | `true`, `false` | `false` means save space by only half-indenting the `where` keyword |
 | `record-brace-space` | `true`, `false` | `rec {x = 1}` vs `rec{x = 1}` |
 | `respectful`         | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
-| `haddock-style`      | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `{-` or `--` |
+| `haddock-style`      | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- |`, `{- |`, or `{-|` (single-line haddocks will always use `--` for now) |
 | `newlines-between-decls` | any integer | number of newlines between top-level declarations |
 | `fixities`           | A list of strings for defining fixities; see the "Language extensions, dependencies, and fixities" section below |
 

--- a/changelog.d/multi-line-compact.md
+++ b/changelog.d/multi-line-compact.md
@@ -1,0 +1,1 @@
+Add `multi-line-compact` option to `haddock-style` that will output `{-|` for multiline haddocks instead of `{- |` ([#130](https://github.com/fourmolu/fourmolu/pull/130))

--- a/data/fourmolu/haddock-style/output-HaddockMultiLineCompact.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLineCompact.hs
@@ -1,0 +1,31 @@
+{-| This is a test multiline
+ module haddock
+-}
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+{-| This is a multiline
+ function haddock
+-}
+multi1 :: Int
+
+{-|
+This is a multiline
+function haddock
+-}
+multi2 :: Int
+
+{-| This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -377,7 +377,8 @@ haddockPrintStyleMap :: BijectiveMap HaddockPrintStyle
 haddockPrintStyleMap =
   $( mkBijectiveMap
       [ ('HaddockSingleLine, "single-line"),
-        ('HaddockMultiLine, "multi-line")
+        ('HaddockMultiLine, "multi-line"),
+        ('HaddockMultiLineCompact, "multi-line-compact")
       ]
    )
 

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -40,6 +40,7 @@ data CommaStyle
 data HaddockPrintStyle
   = HaddockSingleLine
   | HaddockMultiLine
+  | HaddockMultiLineCompact
   deriving (Eq, Show, Enum, Bounded)
 
 data ImportExportStyle

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -168,7 +168,13 @@ p_hsDocString hstyle needsNewline (L l str) = do
       txt $ "-- " <> haddockDelim
       body $ newline >> txt "--"
     else do
-      txt $ "{- " <> haddockDelim
+      txt . T.concat $
+        [ "{-",
+          case (hstyle, printStyle) of
+            (Pipe, HaddockMultiLineCompact) -> ""
+            _ -> " ",
+          haddockDelim
+        ]
       -- 'newline' doesn't allow multiple blank newlines, which changes the comment
       -- if the user writes a comment with multiple newlines. So we have to do this
       -- to force the printer to output a newline. The HaddockSingleLine branch


### PR DESCRIPTION
Blocked on #49?
Related to #74 

It always kinda bothered me when multiline haddocks were formatted like
```hs
{- |
Some multiline
comment here
-}
```
The haddock documentation always uses `{-|` without the space