### PR TITLE
Support test sets for printer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ If there are any options you'd like to see, let us know. If it's not too complic
 
 Run `cabal test` and `./format.sh` before submitting any pull requests.
 
+If you're adding a new customization, please add a new test set for it in the `PrinterSpec` module.
+
 ## License
 
 See [LICENSE.md](LICENSE.md).

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -6,6 +6,7 @@ license-file:       LICENSE.md
 maintainer:
     Matt Parsons <parsonsmatt@gmail.com>
     George Thomas <georgefsthomas@gmail.com>
+
 tested-with:        ghc ==8.8.4 ghc ==8.10.7 ghc ==9.0.1
 homepage:           https://github.com/parsonsmatt/fourmolu
 bug-reports:        https://github.com/parsonsmatt/fourmolu/issues

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Ormolu.PrinterSpec (spec) where
@@ -15,28 +16,56 @@ import Path.IO
 import qualified System.FilePath as F
 import Test.Hspec
 
+-- | A single test case: an input file and the suffix of the expected output file.
+data FormattingTestCase = FormattingTestCase
+  { -- | Input file path relative to `examplesDir`.
+    inputFp :: Path Rel File,
+    -- | Suffix of expected output file.
+    outputFileSuffix :: String
+  }
+
+-- | A test set for a specific set of options, e.g. ormolu's default options,
+-- fourmolu's default options.
+data PrinterOptsTestSet = PrinterOptsTestSet
+  { -- | Config/printer options being used, e.g. indentation, comma-style.
+    po :: PrinterOptsTotal,
+    -- | Test set label, e.g. "ormolu", "fourmolu", "feature X".
+    label :: String,
+    -- | Some customizations might break idepotence. In these cases, the
+    -- idempotence check should be skipped.
+    canBreakIdempotence :: Bool,
+    -- | All input and expected output file pairs, i.e. the test cases.
+    testFiles :: [FormattingTestCase]
+  }
+
 spec :: Spec
 spec = do
-  es <- runIO locateExamples
-  let ormoluOpts =
-        PrinterOpts
-          { poIndentation = pure 2,
-            poCommaStyle = pure Trailing,
-            poIndentWheres = pure True,
-            poRecordBraceSpace = pure True,
-            poDiffFriendlyImportExport = pure False,
-            poRespectful = pure False,
-            poHaddockStyle = pure HaddockSingleLine,
-            poNewlinesBetweenDecls = pure 1
-          }
-  sequence_ $ checkExample <$> [(ormoluOpts, "ormolu", ""), (defaultPrinterOpts, "fourmolu", "-four")] <*> es
+  defaultExamples <- runIO locateExamples
+
+  let allTestSets =
+        sequence
+          -- Add new test sets to this list.
+          [ mkOrmoluOptsSet,
+            mkDefaultOptsSet
+          ]
+          defaultExamples
+
+  mapM_ runConfigTestSet allTestSets
+  where
+    runConfigTestSet :: PrinterOptsTestSet -> Spec
+    runConfigTestSet PrinterOptsTestSet {..} =
+      mapM_
+        ( \FormattingTestCase {..} ->
+            checkExample po label canBreakIdempotence outputFileSuffix inputFp
+        )
+        testFiles
 
 -- | Check a single given example.
-checkExample :: (PrinterOptsTotal, String, String) -> Path Rel File -> Spec
-checkExample (po, label, suffix) srcPath' = it (fromRelFile srcPath' ++ " works (" ++ label ++ ")") . withNiceExceptions $ do
+checkExample :: PrinterOptsTotal -> String -> Bool -> String -> Path Rel File -> Spec
+checkExample po label disableIdempotenceCheck outputFileSuffix srcPath' = it (fromRelFile srcPath' ++ " works (" ++ label ++ ")") . withNiceExceptions $ do
   let srcPath = examplesDir </> srcPath'
       cfg = defaultConfig {cfgPrinterOpts = po}
-  expectedOutputPath <- deriveOutput suffix srcPath
+  expectedOutputPath <- deriveOutput outputFileSuffix srcPath
   -- 1. Given input snippet of source code parse it and pretty print it.
   -- 2. Parse the result of pretty-printing again and make sure that AST
   -- is the same as AST of the original snippet. (This happens in
@@ -48,10 +77,12 @@ checkExample (po, label, suffix) srcPath' = it (fromRelFile srcPath' ++ " works 
   -- writeFile (fromRelFile expectedOutputPath) (T.unpack formatted0)
   expected <- readFileUtf8 $ fromRelFile expectedOutputPath
   shouldMatch False formatted0 expected
-  -- 4. Check that running the formatter on the output produces the same
-  -- output again (the transformation is idempotent).
-  formatted1 <- ormolu cfg "<formatted>" (T.unpack formatted0)
-  shouldMatch True formatted1 formatted0
+
+  unless disableIdempotenceCheck $ do
+    -- 4. Check that running the formatter on the output produces the same
+    -- output again (the transformation is idempotent).
+    formatted1 <- ormolu cfg "<formatted>" (T.unpack formatted0)
+    shouldMatch True formatted1 formatted0
 
 -- | Build list of examples for testing.
 locateExamples :: IO [Path Rel File]
@@ -68,9 +99,9 @@ isInput path =
 
 -- | For given path of input file return expected name of output.
 deriveOutput :: String -> Path Rel File -> IO (Path Rel File)
-deriveOutput suffix path =
+deriveOutput outputFileSuffix path =
   parseRelFile $
-    F.addExtension (F.dropExtensions (fromRelFile path) ++ suffix ++ "-out") "hs"
+    F.addExtension (F.dropExtensions (fromRelFile path) ++ outputFileSuffix ++ "-out") "hs"
 
 -- | A version of 'shouldBe' that is specialized to comparing 'Text' values.
 -- It also prints multi-line snippets in a more readable form.
@@ -102,3 +133,35 @@ withNiceExceptions m = m `catch` h
   where
     h :: OrmoluException -> IO ()
     h = expectationFailure . displayException
+
+-- --------------------------- Test sets ---------------------------
+
+-- Test set config for ormolu's default options.
+mkOrmoluOptsSet :: [Path Rel File] -> PrinterOptsTestSet
+mkOrmoluOptsSet examples =
+  PrinterOptsTestSet
+    { po =
+        PrinterOpts
+          { poIndentation = pure 2,
+            poCommaStyle = pure Trailing,
+            poIndentWheres = pure True,
+            poRecordBraceSpace = pure True,
+            poDiffFriendlyImportExport = pure False,
+            poRespectful = pure False,
+            poHaddockStyle = pure HaddockSingleLine,
+            poNewlinesBetweenDecls = pure 1
+          },
+      label = "ormolu",
+      canBreakIdempotence = False,
+      testFiles = map (`FormattingTestCase` "") examples
+    }
+
+-- Test set config for fourmolu's default options.
+mkDefaultOptsSet :: [Path Rel File] -> PrinterOptsTestSet
+mkDefaultOptsSet examples =
+  PrinterOptsTestSet
+    { po = defaultPrinterOpts,
+      label = "fourmolu",
+      canBreakIdempotence = False,
+      testFiles = map (`FormattingTestCase` "-four") examples
+    }


### PR DESCRIPTION
## What
Refactor the `PrinterSpec` module to support Test Sets. 
Each set will test an instance of `PrinterOpts`, i.e. a combination of fourmolu's customizations.

## How
Define data types to represent a test case and a test set:
- A test case represents an input and the expected output.
- A test set contains:
    - An instance of `PrinterOpts`, which have the combination of options you want to test.
    - A label, e.g. "ormolu" for ormolu's default option.
    - A list of test cases.


This decreases the coupling between the code that defines the configs, examples and file list from the code that runs and checks the examples.

## Why
See #49. Fourmolu now has a lot of options, and we need an easier way to test them properly.

With this change, testing a new combination of options should also be much easier. 

I don't think this should necessarily be the final state, but IMO it's a step in the right direction.

See an example of adding a test suite for a new option in #102.

## RFC and Possible Follow Ups
- I added a `canBreakIdempotence` boolean to the test set data type, because some of the customizations currently under review can do this (e.g. #102, #103). 
    - This is to avoid adding conditions for skipping the idempotence check inside `checkExample`, which shouldn't have any logic specific to an option.

- We could decouple things even more? 
    - Some ideas:
        - Create a separate module for the test set configs and/or new data types.
        - Create separate Specs for each config.
        - Create subfolders for output files, instead of using suffixes.
        - This could make reusing files from other options a bit more confusing, but it would improve the examples directory structure.
    - Since we don't have that many test sets now, I don't think that working on these things is necessary, but I would love to get your thoughts about this.
    
