### PR TITLE
Add `executable` flag to cabal file

### DIFF
--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -113,6 +113,10 @@ library
     if impl(ghc <8.10.0)
         ghc-options: -fmax-pmcheck-iterations=3000000
 
+flag executable
+    description: Build fourmolu executable
+    default: True
+
 executable fourmolu
     main-is:          Main.hs
     hs-source-dirs:   app
@@ -137,6 +141,9 @@ executable fourmolu
 
     else
         ghc-options: -O2 -Wall -rtsopts
+
+    if !flag(executable)
+        buildable: False
 
 test-suite tests
     type:               exitcode-stdio-1.0


### PR DESCRIPTION
This package is pulled in by the [fourmolu plugin](https://github.com/haskell/haskell-language-server/tree/master/plugins/hls-fourmolu-plugin) for `haskell-language-server`, therefore some users will not wish to build/install the executable. This gives the option to disable it, although this is not the default.