### PR TITLE
Add haddock-style-module configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Defaults are in bold.
 | `record-brace-space`     | `true`, **`false`**                                   | `rec {x = 1}` _vs_ `rec{x = 1}`
 | `newlines-between-decls` | any integer (**`1`**)                                 | Number of newlines between top-level declarations
 | `haddock-style`          | `single-line`, **`multi-line`**, `multi-line-compact` | Use `-- \|`, `{- \|`, or `{-\|` for multiline haddocks (single-line haddocks always use `--`)
+| `haddock-style-module`   | same as `haddock-style`                               | `haddock-style`, but specifically for the module docstring (not specifying anything = use the same setting as `haddock-style`) |
 | `let-style`              | `inline`, `newline`, **`auto`**, `mixed`              | How to style `let` blocks (`auto` uses `newline` if there's a newline in the input and `inline` otherwise, and `mixed` uses `inline` only when the `let` has exactly one binding)
 | `in-style`               | `left-align`, **`right-align`**                       | How to align the `in` keyword with respect to `let`
 | `unicode`                | `always`, `detect`, **`never`**                       | Output Unicode syntax. With `detect` we output Unicode syntax exactly when the extension is seen to be enabled.
@@ -76,6 +77,7 @@ indent-wheres: false
 record-brace-space: false
 newlines-between-decls: 1
 haddock-style: multi-line
+haddock-style-module:
 let-style: auto
 in-style: right-align
 respectful: true
@@ -94,6 +96,7 @@ indent-wheres: true
 record-brace-space: true
 newlines-between-decls: 1
 haddock-style: single-line
+haddock-style-module:
 let-style: inline
 in-style: right-align
 respectful: false

--- a/changelog.d/haddock-style-module.md
+++ b/changelog.d/haddock-style-module.md
@@ -1,0 +1,1 @@
+Add `haddock-style-module` option ([#135](https://github.com/fourmolu/fourmolu/pull/135))

--- a/data/fourmolu/haddock-style/output-HaddockMultiLine-module=HaddockMultiLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLine-module=HaddockMultiLine.hs
@@ -1,0 +1,31 @@
+{- | This is a test multiline
+ module haddock
+-}
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+{- | This is a multiline
+ function haddock
+-}
+multi1 :: Int
+
+{- |
+This is a multiline
+function haddock
+-}
+multi2 :: Int
+
+{- | This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockMultiLine-module=HaddockMultiLineCompact.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLine-module=HaddockMultiLineCompact.hs
@@ -1,0 +1,31 @@
+{-| This is a test multiline
+ module haddock
+-}
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+{- | This is a multiline
+ function haddock
+-}
+multi1 :: Int
+
+{- |
+This is a multiline
+function haddock
+-}
+multi2 :: Int
+
+{- | This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockMultiLine-module=HaddockSingleLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLine-module=HaddockSingleLine.hs
@@ -1,0 +1,30 @@
+-- | This is a test multiline
+-- module haddock
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+{- | This is a multiline
+ function haddock
+-}
+multi1 :: Int
+
+{- |
+This is a multiline
+function haddock
+-}
+multi2 :: Int
+
+{- | This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockMultiLineCompact-module=HaddockMultiLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLineCompact-module=HaddockMultiLine.hs
@@ -1,0 +1,31 @@
+{- | This is a test multiline
+ module haddock
+-}
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+{-| This is a multiline
+ function haddock
+-}
+multi1 :: Int
+
+{-|
+This is a multiline
+function haddock
+-}
+multi2 :: Int
+
+{-| This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockMultiLineCompact-module=HaddockMultiLineCompact.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLineCompact-module=HaddockMultiLineCompact.hs
@@ -1,0 +1,31 @@
+{-| This is a test multiline
+ module haddock
+-}
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+{-| This is a multiline
+ function haddock
+-}
+multi1 :: Int
+
+{-|
+This is a multiline
+function haddock
+-}
+multi2 :: Int
+
+{-| This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockMultiLineCompact-module=HaddockSingleLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLineCompact-module=HaddockSingleLine.hs
@@ -1,0 +1,30 @@
+-- | This is a test multiline
+-- module haddock
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+{-| This is a multiline
+ function haddock
+-}
+multi1 :: Int
+
+{-|
+This is a multiline
+function haddock
+-}
+multi2 :: Int
+
+{-| This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockSingleLine-module=HaddockMultiLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockSingleLine-module=HaddockMultiLine.hs
@@ -1,0 +1,28 @@
+{- | This is a test multiline
+ module haddock
+-}
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+-- | This is a multiline
+-- function haddock
+multi1 :: Int
+
+-- |
+--This is a multiline
+--function haddock
+multi2 :: Int
+
+-- | This is a haddock
+--
+-- with two consecutive newlines
+--
+--
+-- https://github.com/fourmolu/fourmolu/issues/172
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockSingleLine-module=HaddockMultiLineCompact.hs
+++ b/data/fourmolu/haddock-style/output-HaddockSingleLine-module=HaddockMultiLineCompact.hs
@@ -1,0 +1,28 @@
+{-| This is a test multiline
+ module haddock
+-}
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+-- | This is a multiline
+-- function haddock
+multi1 :: Int
+
+-- |
+--This is a multiline
+--function haddock
+multi2 :: Int
+
+-- | This is a haddock
+--
+-- with two consecutive newlines
+--
+--
+-- https://github.com/fourmolu/fourmolu/issues/172
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockSingleLine-module=HaddockSingleLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockSingleLine-module=HaddockSingleLine.hs
@@ -1,0 +1,27 @@
+-- | This is a test multiline
+-- module haddock
+module Foo where
+
+-- | This is a singleline function haddock
+single1 :: Int
+
+-- | This is a singleline function haddock
+single2 :: Int
+
+-- | This is a multiline
+-- function haddock
+multi1 :: Int
+
+-- |
+--This is a multiline
+--function haddock
+multi2 :: Int
+
+-- | This is a haddock
+--
+-- with two consecutive newlines
+--
+--
+-- https://github.com/fourmolu/fourmolu/issues/172
+foo :: Int
+foo = 42

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -7,6 +7,7 @@ indent-wheres: true
 record-brace-space: true
 newlines-between-decls: 1
 haddock-style: single-line
+haddock-style-module:
 let-style: inline
 in-style: right-align
 unicode: never

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -34,6 +34,7 @@ module Ormolu.Config
     fillMissingPrinterOpts,
     CommaStyle (..),
     HaddockPrintStyle (..),
+    HaddockPrintStyleModule (..),
     ImportExportStyle (..),
     LetStyle (..),
     InStyle (..),
@@ -227,6 +228,7 @@ overFieldsM f $(unpackFieldsWithSuffix 'PrinterOpts "0") = do
   poRecordBraceSpace <- f poRecordBraceSpace0
   poNewlinesBetweenDecls <- f poNewlinesBetweenDecls0
   poHaddockStyle <- f poHaddockStyle0
+  poHaddockStyleModule <- f poHaddockStyleModule0
   poLetStyle <- f poLetStyle0
   poInStyle <- f poInStyle0
   poUnicode <- f poUnicode0
@@ -343,6 +345,14 @@ printerOptsMeta =
                 "How to print Haddock comments (choices: %s)"
                 (showAllValues haddockPrintStyleMap),
             metaDefault = HaddockMultiLine
+          },
+      poHaddockStyleModule =
+        PrinterOptsFieldMeta
+          { metaName = "haddock-style-module",
+            metaGetField = poHaddockStyleModule,
+            metaPlaceholder = "STYLE",
+            metaHelp = "How to print module docstring",
+            metaDefault = PrintStyleInherit
           },
       poLetStyle =
         PrinterOptsFieldMeta
@@ -481,6 +491,18 @@ instance PrinterOptsFieldType HaddockPrintStyle where
   parseJSON = parseJSONWith haddockPrintStyleMap "HaddockPrintStyle"
   parseText = parseTextWith haddockPrintStyleMap
   showText = show . showTextWith haddockPrintStyleMap
+
+instance PrinterOptsFieldType HaddockPrintStyleModule where
+  parseJSON = \case
+    Aeson.Null -> pure PrintStyleInherit
+    Aeson.String "" -> pure PrintStyleInherit
+    v -> PrintStyleOverride <$> parseJSON v
+  parseText = \case
+    "" -> pure PrintStyleInherit
+    s -> PrintStyleOverride <$> parseText s
+  showText = \case
+    PrintStyleInherit -> "same as 'haddock-style'"
+    PrintStyleOverride x -> showText x
 
 instance PrinterOptsFieldType ImportExportStyle where
   parseJSON = parseJSONWith importExportStyleMap "ImportExportStyle"

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -6,6 +6,7 @@ module Ormolu.Config.Types
     CommaStyle (..),
     FunctionArrowsStyle (..),
     HaddockPrintStyle (..),
+    HaddockPrintStyleModule (..),
     ImportExportStyle (..),
     LetStyle (..),
     InStyle (..),
@@ -33,6 +34,8 @@ data PrinterOpts f = PrinterOpts
     poNewlinesBetweenDecls :: f Int,
     -- | How to print doc comments
     poHaddockStyle :: f HaddockPrintStyle,
+    -- | How to print the module docstring (defaults to poHaddockStyle)
+    poHaddockStyleModule :: f HaddockPrintStyleModule,
     -- | Styling of let blocks
     poLetStyle :: f LetStyle,
     -- | How to align in keyword
@@ -59,6 +62,11 @@ data HaddockPrintStyle
   | HaddockMultiLine
   | HaddockMultiLineCompact
   deriving (Eq, Show, Enum, Bounded)
+
+data HaddockPrintStyleModule
+  = PrintStyleInherit
+  | PrintStyleOverride HaddockPrintStyle
+  deriving (Eq, Show)
 
 data ImportExportStyle
   = ImportExportLeading

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -61,7 +61,11 @@ p_hsModule mstackHeader pragmas hsmod@HsModule {..} = do
 p_hsModuleHeader :: HsModule -> LocatedA ModuleName -> R ()
 p_hsModuleHeader HsModule {..} moduleName = do
   located moduleName $ \name -> do
-    forM_ hsmodHaddockModHeader (p_hsDocString Pipe True)
+    poHStyle <-
+      getPrinterOpt poHaddockStyleModule >>= \case
+        PrintStyleInherit -> getPrinterOpt poHaddockStyle
+        PrintStyleOverride style -> pure style
+    forM_ hsmodHaddockModHeader (p_hsDocString' poHStyle Pipe True)
     p_hsmodName name
 
   forM_ hsmodDeprecMessage $ \w -> do

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -28,6 +28,7 @@ import Ormolu
     detectSourceType,
     ormolu,
   )
+import Ormolu.Config (HaddockPrintStyleModule (..))
 import Ormolu.Exception (OrmoluException, printOrmoluException)
 import Ormolu.Terminal (ColorMode (..), runTerm)
 import Ormolu.Utils.IO (readFileUtf8, writeFileUtf8)
@@ -130,10 +131,24 @@ singleTests =
         },
       TestGroup
         { label = "haddock-style",
-          testCases = allOptions,
-          updateConfig = \haddockStyle opts -> opts {poHaddockStyle = pure haddockStyle},
-          showTestCase = show,
-          testCaseSuffix = suffix1
+          testCases = (,) <$> allOptions <*> (PrintStyleInherit : map PrintStyleOverride allOptions),
+          updateConfig = \(haddockStyle, haddockStyleModule) opts ->
+            opts
+              { poHaddockStyle = pure haddockStyle,
+                poHaddockStyleModule = pure haddockStyleModule
+              },
+          showTestCase = \(haddockStyle, haddockStyleModule) ->
+            show haddockStyle
+              ++ case haddockStyleModule of
+                PrintStyleInherit -> ""
+                PrintStyleOverride style -> " + module=" ++ show style,
+          testCaseSuffix = \(haddockStyle, haddockStyleModule) ->
+            suffixWith
+              [ show haddockStyle,
+                case haddockStyleModule of
+                  PrintStyleInherit -> ""
+                  PrintStyleOverride style -> "module=" ++ show style
+              ]
         },
       TestGroup
         { label = "let-style",


### PR DESCRIPTION
Blocked on #49?
Resolves https://github.com/fourmolu/fourmolu/issues/74

Adds a `haddock-style-module` option that specifies the haddock style to use specifically for the module docstring (when not set, resolves to whatever `haddock-style` is — the current behavior)

Tested with this file:
```hs
{- |
Module: Foo
-}

module Foo where

-- | This is a
-- multi line
-- haddock
foo :: Int
foo = 42
```
and this command:
```console
$ stack exec -- fourmolu --haddock-style=single-line --haddock-style-module=multi-line Foo.hs

{- |
Module: Foo
-}
module Foo where

-- | This is a
-- multi line
-- haddock
foo :: Int
foo = 42
```