### PR TITLE
Support aeson 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ cabal.project.local
 cabal.sandbox.config
 dist-*/
 dist/
-stack.yaml.lock
+stack*.yaml.lock
 result*

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -82,7 +82,7 @@ library
     default-language: Haskell2010
     build-depends:
         Diff >=0.4 && <1.0,
-        aeson >=1.4.0.0 && <1.6,
+        aeson >=1.4.0.0 && <2.1,
         ansi-terminal >=0.10 && <1.0,
         base >=4.12 && <5.0,
         bytestring >=0.2 && <0.12,

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -1,4 +1,7 @@
 resolver: nightly-2021-11-28
 
+extra-deps:
+  - aeson-2.0.2.0
+
 ghc-options:
   '$locals': -Werror

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -1,7 +1,4 @@
-resolver: nightly-2021-08-08
-
-extra-deps:
-  - ghc-lib-parser-9.0.1.20210324
+resolver: nightly-2021-11-28
 
 ghc-options:
   '$locals': -Werror


### PR DESCRIPTION
Fourmolu works with aeson 2 out of the box, so I already bumped the Hackage bounds for aeson 2: https://hackage.haskell.org/package/fourmolu-0.4.0.0/revisions/