### PR TITLE
Avoid setting Ormolu dev flag in Cabal config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       # build
       - run:
           name: Build
-          command: stack build --test --no-run-tests
+          command: stack build --test --no-run-tests --flag fourmolu:dev
 
       # lint
       - when:
@@ -88,7 +88,9 @@ jobs:
       # test
       - run:
           name: Test
-          command: stack test
+          command:
+            # keep the dev flag here to avoid rebuilding from the build step
+            stack test --flag fourmolu:dev
 
       # build haddock
       - when:

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,1 @@
 packages: .
-
-constraints: ormolu +dev

--- a/stack-ghc-8.10.yaml
+++ b/stack-ghc-8.10.yaml
@@ -3,6 +3,3 @@ resolver: lts-18.12
 extra-deps:
   - Cabal-3.6.2.0
   - ghc-lib-parser-9.2.1.20211101
-
-ghc-options:
-  '$locals': -Werror

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -3,6 +3,3 @@ resolver: nightly-2021-11-28
 extra-deps:
   - Cabal-3.6.2.0
   - ghc-lib-parser-9.2.1.20211101
-
-ghc-options:
-  '$locals': -Werror

--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -8,6 +8,3 @@ extra-deps:
   - base-compat-batteries-0.12.1
   - Cabal-3.6.2.0
   - ghc-lib-parser-9.2.1.20211101
-
-ghc-options:
-  '$locals': -Werror


### PR DESCRIPTION
Carrying on the conversation from https://github.com/fourmolu/fourmolu/pull/129#issuecomment-981870050:

> I actually intentionally want `-Werror` on in local development. If it's gonna fail in CI, why not have it fail locally? `cabal.project` also has it nominally on (although it should be updated to `fourmolu +dev` instead of `ormolu +dev`), so I'd rather we change it so both Stack and Cabal have `-Werror` on in local development

I've never personally understood the desire to enable `-Werror`, other than when one wants to ensure that builds output a non-zero exit code in the presence of warnings, e.g. in CI. During interactive development, surely it's often useful to run code that contains potentially-harmless issues like unused variables, or missing type signatures? I feel like I must be missing something.

Anyway, while this PR doesn't really change anything, it draws attention to the fact that we enable `-Werror` when building with Stack, but not Cabal, which is weird.