### PR TITLE
Fix indentation after list comprehension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixed regression in 0.5.0.0 with multiline tuples ([#162](https://github.com/fourmolu/fourmolu/pull/162))
 * Fixed regression in 0.5.0.0 with multiline record types ([#160](https://github.com/fourmolu/fourmolu/pull/160))
+* Fixed regression in 0.5.0.0 with indentation after a list comprehension ([#149](https://github.com/fourmolu/fourmolu/pull/149))
 * Add `import-export-comma-style` configuration to allow leading commas in module import/export lists
 
 ## Fourmolu 0.5.0.0

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -157,7 +157,7 @@ p_conDecl singleConstRec = \case
     mapM_ (p_hsDocString Pipe True) con_doc
     let conDeclWithContextSpn =
           [RealSrcSpan real Nothing | AddEpAnn AnnForall (EpaSpan real) <- epAnnAnns con_ext]
-          <> fmap getLocA con_ex_tvs
+            <> fmap getLocA con_ex_tvs
             <> maybeToList (fmap getLocA con_mb_cxt)
             <> conDeclSpn
         conDeclSpn = getLocA con_name : conArgsSpans


### PR DESCRIPTION
Fixes #142 

Ormolu refactored all this code after 0.4.0.0 was released, so this code will probably go away. But fixes the weirdness for now.

Ref. https://github.com/tweag/ormolu/pull/830