### PR TITLE
Add single source of truth for JSON/CLI configuration

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -52,9 +52,10 @@ main :: IO ()
 main = do
   opts@Opts {..} <- execParser optsParserInfo
 
+  cwd <- getCurrentDirectory
   cfg <- case optInputFiles of
-    [] -> mkConfigFromCWD opts
-    ["-"] -> mkConfigFromCWD opts
+    [] -> mkConfig cwd opts
+    ["-"] -> mkConfig cwd opts
     file : _ -> mkConfig file opts
   let formatOne' =
         formatOne
@@ -564,11 +565,6 @@ mkConfig path Opts {..} = do
       }
   where
     printDebug = when (cfgDebug optConfig) . hPutStrLn stderr
-
-mkConfigFromCWD :: Opts -> IO (Config RegionIndices)
-mkConfigFromCWD opts = do
-  cwd <- getCurrentDirectory
-  mkConfig cwd opts
 
 -- | Parse 'Mode'.
 parseMode :: ReadM Mode

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -87,6 +87,9 @@ library
         Ormolu.Utils.Cabal
         Ormolu.Utils.Fixity
         Ormolu.Utils.IO
+    other-modules:
+        Ormolu.Config.TH
+        Ormolu.Config.Types
 
     hs-source-dirs:   src
     other-modules:    GHC.DynFlags
@@ -115,7 +118,7 @@ library
         -- fourmolu-only deps
         yaml >=0.11.6.0 && <1
 
-    mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
+    mixins:           ghc-lib-parser hiding (Language.Haskell.TH, Language.Haskell.TH.Syntax)
 
     if flag(fixity-th)
         cpp-options: -DFIXITY_TH

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -244,26 +244,19 @@ fillMissingPrinterOpts ::
   PrinterOptsPartial ->
   PrinterOpts f ->
   PrinterOpts f
-fillMissingPrinterOpts p1 p2 =
-  PrinterOpts
-    { poIndentation = fillField poIndentation,
-      poCommaStyle = fillField poCommaStyle,
-      poImportExportCommaStyle = fillField poImportExportCommaStyle,
-      poIndentWheres = fillField poIndentWheres,
-      poRecordBraceSpace = fillField poRecordBraceSpace,
-      poDiffFriendlyImportExport = fillField poDiffFriendlyImportExport,
-      poRespectful = fillField poRespectful,
-      poHaddockStyle = fillField poHaddockStyle,
-      poNewlinesBetweenDecls = fillField poNewlinesBetweenDecls
-    }
+fillMissingPrinterOpts p1 p2 = overFields fillField printerOptsMeta
   where
-    fillField :: (forall g. PrinterOpts g -> g a) -> f a
-    fillField f = maybe (f p2) pure $ f p1
+    fillField :: PrinterOptsFieldMeta a -> f a
+    fillField meta = maybe (metaGetField meta p2) pure (metaGetField meta p1)
 
 -- | Source of truth for how PrinterOpts is parsed from configuration sources.
 data PrinterOptsFieldMeta a where
   PrinterOptsFieldMeta ::
-    { metaDefault :: a
+    { -- In future versions of GHC, this could be replaced with a
+      -- `metaProxyField = Proxy @"poIndentation"` field using `HasField`
+      -- https://gitlab.haskell.org/ghc/ghc/-/issues/20989
+      metaGetField :: forall f. PrinterOpts f -> f a,
+      metaDefault :: a
     } ->
     PrinterOptsFieldMeta a
 
@@ -272,39 +265,48 @@ printerOptsMeta =
   PrinterOpts
     { poIndentation =
         PrinterOptsFieldMeta
-          { metaDefault = 4
+          { metaGetField = poIndentation,
+            metaDefault = 4
           },
       poCommaStyle =
         PrinterOptsFieldMeta
-          { metaDefault = Leading
+          { metaGetField = poCommaStyle,
+            metaDefault = Leading
           },
       poImportExportCommaStyle =
         PrinterOptsFieldMeta
-          { metaDefault = Trailing
+          { metaGetField = poImportExportCommaStyle,
+            metaDefault = Trailing
           },
       poIndentWheres =
         PrinterOptsFieldMeta
-          { metaDefault = False
+          { metaGetField = poIndentWheres,
+            metaDefault = False
           },
       poRecordBraceSpace =
         PrinterOptsFieldMeta
-          { metaDefault = False
+          { metaGetField = poRecordBraceSpace,
+            metaDefault = False
           },
       poDiffFriendlyImportExport =
         PrinterOptsFieldMeta
-          { metaDefault = True
+          { metaGetField = poDiffFriendlyImportExport,
+            metaDefault = True
           },
       poRespectful =
         PrinterOptsFieldMeta
-          { metaDefault = True
+          { metaGetField = poRespectful,
+            metaDefault = True
           },
       poHaddockStyle =
         PrinterOptsFieldMeta
-          { metaDefault = HaddockMultiLine
+          { metaGetField = poHaddockStyle,
+            metaDefault = HaddockMultiLine
           },
       poNewlinesBetweenDecls =
         PrinterOptsFieldMeta
-          { metaDefault = 1
+          { metaGetField = poNewlinesBetweenDecls,
+            metaDefault = 1
           }
     }
 

--- a/src/Ormolu/Config/TH.hs
+++ b/src/Ormolu/Config/TH.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Ormolu.Config.TH
+  ( allNothing,
+    unpackFieldsWithSuffix,
+  )
+where
+
+import Control.Monad ((>=>))
+import Language.Haskell.TH
+import Text.Printf (printf)
+
+allNothing :: Name -> Q Exp
+allNothing name = do
+  ty <- reifyType name
+  foldl appE (conE name) $
+    replicate (getArity ty) [|Nothing|]
+
+unpackFieldsWithSuffix :: Name -> String -> Q Pat
+unpackFieldsWithSuffix name suffix = do
+  typeForCon <-
+    reify name >>= \case
+      DataConI _ _ typeForCon -> return typeForCon
+      info -> fail $ "allNothing requires the Name of a data constructor, got: " <> show info
+
+  allConsInType <-
+    getAllConstructors typeForCon
+      >>= either (fail . printf "Unexpected parent of data constructor: %s" . show) return
+
+  fields <-
+    case filter (elem name . getConstructorNames) allConsInType of
+      [con] | Just fields <- conFieldNames con -> return fields
+      _ -> fail $ "Could not find unique record constructor in: " <> show allConsInType
+
+  conP name $ map (varP . mkName . (<> suffix) . nameBase) fields
+  where
+    conFieldNames = \case
+      NormalC {} -> Nothing
+      RecC _ tys -> Just $ map fst3 tys
+      InfixC {} -> Nothing
+      ForallC {} -> Nothing
+      GadtC {} -> Nothing
+      RecGadtC _ tys _ -> Just $ map fst3 tys
+    fst3 (x, _, _) = x
+
+----------------------------------------------------------------------------
+-- Helpers
+
+{- FOURMOLU_DISABLE -}
+{- https://github.com/fourmolu/fourmolu#limitations -}
+getArity :: Type -> Int
+getArity = \case
+  ForallT _ _ ty -> getArity ty
+  AppT (AppT ArrowT _) ty -> 1 + getArity ty
+#if MIN_VERSION_template_haskell(2,17,0)
+  AppT (AppT (AppT MulArrowT _) _) ty -> 1 + getArity ty
+#endif
+  _ -> 0
+{- FOURMOLU_ENABLE -}
+
+getAllConstructors :: Name -> Q (Either Info [Con])
+getAllConstructors =
+  reify >=> \case
+    TyConI (DataD _ _ _ _ cons _) -> return $ Right cons
+    info -> return $ Left info
+
+-- Could return multiple names for GADTs like 'A, B :: Foo'
+getConstructorNames :: Con -> [Name]
+getConstructorNames = \case
+  NormalC n _ -> [n]
+  RecC n _ -> [n]
+  InfixC _ n _ -> [n]
+  ForallC _ _ c -> getConstructorNames c
+  GadtC ns _ _ -> ns
+  RecGadtC ns _ _ -> ns

--- a/src/Ormolu/Config/TH.hs
+++ b/src/Ormolu/Config/TH.hs
@@ -5,11 +5,20 @@
 module Ormolu.Config.TH
   ( allNothing,
     unpackFieldsWithSuffix,
+
+    -- * BijectiveMap
+    BijectiveMap,
+    mkBijectiveMap,
+    parseTextWith,
+    showTextWith,
+    showAllValues,
   )
 where
 
-import Control.Monad ((>=>))
+import Control.Monad (forM, (>=>))
+import Data.List (intercalate, nub)
 import Language.Haskell.TH
+import Language.Haskell.TH.Syntax (lift)
 import Text.Printf (printf)
 
 allNothing :: Name -> Q Exp
@@ -45,6 +54,90 @@ unpackFieldsWithSuffix name suffix = do
       RecGadtC _ tys _ -> Just $ map fst3 tys
     fst3 (x, _, _) = x
 
+data BijectiveMap a = BijectiveMap
+  { parseTextWith :: String -> Either String a,
+    showTextWith :: a -> String,
+    getAllOptions :: [String]
+  }
+
+showAllValues :: BijectiveMap a -> String
+showAllValues = uncommas . map show . getAllOptions
+
+-- | Generate a `BijectiveMap a` value with the given map.
+--
+-- Checks the following:
+--   * all Names in given list refer to a constructor of type `a`
+--   * all Names in given list refer to a 0-arity constructor
+--   * all constructors in type `a` are accounted for.
+mkBijectiveMap :: [(Name, String)] -> Q Exp
+mkBijectiveMap mapping = do
+  let (conNames, allOptions) = unzip mapping
+
+  -- check all names refer to constructors
+  (conTypes, conParents) <-
+    fmap unzip . forM conNames $ \name ->
+      reify name >>= \case
+        DataConI _ ty parent -> pure (ty, parent)
+        info ->
+          fail $
+            printf
+              "mkBijectiveMap requires all Names refer to data constructors, got %s: %s"
+              (show name)
+              (show info)
+
+  -- check that all constructors are in same type
+  parent <-
+    case nub conParents of
+      [parent] -> return parent
+      parents -> fail $ "mkBijectiveMap requires all Names refer to data constructors in the same type, got: " <> show parents
+
+  -- check that all constructors are 0-arity
+  case filter ((/= 0) . getArity) conTypes of
+    [] -> return ()
+    _ -> fail "mkBijectiveMap requires all constructors have 0-arity"
+
+  -- check that all constructors are represented
+  allConsInType <-
+    getAllConstructors parent
+      >>= either (fail . printf "Unexpected parent of data constructors: %s" . show) return
+  case filter (`notElem` conNames) (concatMap getConstructorNames allConsInType) of
+    [] -> return ()
+    missing -> fail $ "Missing constructors: " ++ show missing
+
+  unknown <- newName "unknown"
+  let parser =
+        lamCaseE . concat $
+          [ flip map mapping $ \(name, option) ->
+              match
+                (litP $ stringL option)
+                (normalB [|Right $(conE name)|])
+                [],
+            [ match
+                (varP unknown)
+                ( normalB
+                    [|
+                      Left . unlines $
+                        [ "unknown value: " <> show $(varE unknown),
+                          "Valid values are: " <> $(lift $ uncommas $ map show allOptions)
+                        ]
+                      |]
+                )
+                []
+            ]
+          ]
+      shower =
+        lamCaseE $
+          flip map mapping $ \(name, option) ->
+            match (conP name []) (normalB $ lift option) []
+
+  [|
+    BijectiveMap
+      { parseTextWith = $parser,
+        showTextWith = $shower,
+        getAllOptions = $(lift allOptions)
+      }
+    |]
+
 ----------------------------------------------------------------------------
 -- Helpers
 
@@ -75,3 +168,12 @@ getConstructorNames = \case
   ForallC _ _ c -> getConstructorNames c
   GadtC ns _ _ -> ns
   RecGadtC ns _ _ -> ns
+
+uncommas :: [String] -> String
+uncommas [] = ""
+uncommas [s] = s
+uncommas [s0, s1] = s0 <> " or " <> s1
+uncommas ss =
+  let pre = init ss
+      end = last ss
+   in intercalate ", " pre <> "or " <> end

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+-- | This module only defines PrinterOpts, needed to be separate because of
+-- Template Haskell staging restrictions.
+module Ormolu.Config.Types
+  ( PrinterOpts (..),
+    CommaStyle (..),
+    HaddockPrintStyle (..),
+  )
+where
+
+import GHC.Generics (Generic)
+
+-- | Options controlling formatting output.
+data PrinterOpts f = PrinterOpts
+  { -- | Number of spaces to use for indentation
+    poIndentation :: f Int,
+    -- | Whether to place commas at start or end of lines
+    poCommaStyle :: f CommaStyle,
+    -- | Whether to place commas at start or end of import-export lines
+    poImportExportCommaStyle :: f CommaStyle,
+    -- | Whether to indent `where` blocks
+    poIndentWheres :: f Bool,
+    -- | Leave space before opening record brace
+    poRecordBraceSpace :: f Bool,
+    -- | Trailing commas with parentheses on separate lines
+    poDiffFriendlyImportExport :: f Bool,
+    -- | Be less opinionated about spaces/newlines etc.
+    poRespectful :: f Bool,
+    -- | How to print doc comments
+    poHaddockStyle :: f HaddockPrintStyle,
+    -- | Number of newlines between top-level decls
+    poNewlinesBetweenDecls :: f Int
+  }
+  deriving (Generic)
+
+data CommaStyle
+  = Leading
+  | Trailing
+  deriving (Eq, Ord, Show, Generic, Bounded, Enum)
+
+data HaddockPrintStyle
+  = HaddockSingleLine
+  | HaddockMultiLine
+  deriving (Eq, Ord, Show, Generic, Bounded, Enum)

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -37,9 +37,9 @@ data PrinterOpts f = PrinterOpts
 data CommaStyle
   = Leading
   | Trailing
-  deriving (Eq, Ord, Show, Generic, Bounded, Enum)
+  deriving (Eq, Show, Enum, Bounded)
 
 data HaddockPrintStyle
   = HaddockSingleLine
   | HaddockMultiLine
-  deriving (Eq, Ord, Show, Generic, Bounded, Enum)
+  deriving (Eq, Show, Enum, Bounded)

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -426,7 +426,7 @@ inciBy step (R m) = R (local modRC m)
 -- | Like 'inci', but indents by the given fraction of a full step.
 inciByFrac :: Int -> R () -> R ()
 inciByFrac x m = do
-  indentStep <- R $ asks (runIdentity . poIndentation . rcPrinterOpts)
+  indentStep <- getPrinterOpt poIndentation
   let step = indentStep `quot` x
   inciBy step m
 


### PR DESCRIPTION
Resolves https://github.com/fourmolu/fourmolu/issues/50

Help text:
```diff
-  --indentation WIDTH      Number of spaces per indentation step (default '4')
-  --comma-style STYLE      How to place commas in multi-line lists, records etc:
-                           'leading' or 'trailing' (default 'leading')
+  --indentation WIDTH      Number of spaces per indentation step (default: 4)
+  --comma-style STYLE      How to place commas in multi-line lists, records,
+                           etc. (choices: "leading" or "trailing")
+                           (default: "leading")
   --indent-wheres BOOL     Whether to indent 'where' bindings past the preceding
                            body (rather than half-indenting the 'where' keyword)
-                           (default 'false')
+                           (default: False)
   --record-brace-space BOOL
                            Whether to leave a space before an opening record
-                           brace (default 'false')
+                           brace (default: False)
   --diff-friendly-import-export BOOL
                            Whether to make use of extra commas in import/export
-                           lists (as opposed to Ormolu's style) (default 'true')
+                           lists (as opposed to Ormolu's style) (default: True)
   --respectful BOOL        Give the programmer more choice on where to insert
-                           blank lines (default 'true')
-  --haddock-style STYLE    How to print Haddock comments: 'single-line' or
-                           'multi-line' (default 'multi-line')
+                           blank lines (default: True)
+  --haddock-style STYLE    How to print Haddock comments (choices: "single-line"
+                           or "multi-line") (default: "multi-line")
   --newlines-between-decls HEIGHT
                            Number of spaces between top-level declarations
-                           (default '1')
+                           (default: 1)
```

Config parse failure:
```
# old
Failed to load fourmolu.yaml:
Aeson exception:
Error in $['comma-style']: parsing Ormolu.Config.CommaStyle failed, expected one of the tags ["leading","trailing"], but found tag "asdf"

# new
Failed to load fourmolu.yaml:
Aeson exception:
Error in $['comma-style']: unknown value: "asdf"
Valid values are: "leading" or "trailing"
```

CLI parse failure:
```console
# old
$ stack exec -- fourmolu --comma-style=asdf
option --comma-style: unknown value: 'asdf'
Valid values are: 'leading' or 'trailing'.

# new
$ stack exec -- fourmolu --comma-style=asdf
option --comma-style: unknown value: "asdf"
Valid values are: "leading" or "trailing"
```

---

If you're curious about the splices:
```
Ormolu/Config.hs:177:14-36: Splicing expression
    allNothing 'PrinterOpts
  ======>
    (((((((PrinterOpts Nothing) Nothing) Nothing) Nothing) Nothing)
        Nothing)
       Nothing)
      Nothing
```
```
Ormolu/Config.hs:198:17-55: Splicing pattern
    unpackFieldsWithSuffix 'PrinterOpts "0"
  ======>
    PrinterOpts poIndentation0 poCommaStyle0 poIndentWheres0
                poRecordBraceSpace0 poDiffFriendlyImportExport0 poRespectful0
                poHaddockStyle0 poNewlinesBetweenDecls0
```
```
Ormolu/Config.hs:(349,6)-(352,7): Splicing expression
    mkBijectiveMap
      [('HaddockSingleLine, "single-line"),
       ('HaddockMultiLine, "multi-line")]
  ======>
    Ormolu.Config.TH.BijectiveMap
      {parseTextWith = \case
                         "single-line" -> Right HaddockSingleLine
                         "multi-line" -> Right HaddockMultiLine
                         unknown_aiad
                           -> ((Left . unlines)
                                 $ [("unknown value: " <> show unknown_aiad),
                                    ("Valid values are: " <> ""single-line" or "multi-line"")]),
       showTextWith = \case
                        HaddockSingleLine -> "single-line"
                        HaddockMultiLine -> "multi-line",
       Ormolu.Config.TH.getAllOptions = ["single-line", "multi-line"]}
```
You can try the following things to make `mkBijectiveMap` fail:
* Add a `Foo` constructor to `CommaStyle`
* Change `'Trailing` to `'HaddockSingleLine`
* Add a `String` argument to `Trailing`