### PR TITLE
"Consistent Let" option

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -384,6 +384,14 @@ printerOptsParser = do
           "Number of spaces between top-level declarations"
             <> showDefaultValue poNewlinesBetweenDecls
       ]
+  poConsistentLet <-
+    (optional . option parseBoundedEnum . mconcat)
+      [ long "consistent-let",
+        metavar "BOOL",
+        help $
+          "Whether to lay out 'let' similar to 'do', 'case', and '\\case'"
+            <> showDefaultValue poConsistentLet
+      ]
   pure PrinterOpts {..}
 
 sourceTypeParser :: Parser (Maybe SourceType)

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -137,7 +137,9 @@ data PrinterOpts f = PrinterOpts
     -- | How to print doc comments
     poHaddockStyle :: f HaddockPrintStyle,
     -- | Number of newlines between top-level decls
-    poNewlinesBetweenDecls :: f Int
+    poNewlinesBetweenDecls :: f Int,
+    -- | Whether to lay out let the same as do, case, and lambda-case
+    poConsistentLet :: f Bool
   }
   deriving (Generic)
 
@@ -153,7 +155,7 @@ instance Semigroup PrinterOptsPartial where
   (<>) = fillMissingPrinterOpts
 
 instance Monoid PrinterOptsPartial where
-  mempty = PrinterOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+  mempty = PrinterOpts Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 -- | A version of 'PrinterOpts' without empty fields.
 type PrinterOptsTotal = PrinterOpts Identity
@@ -172,7 +174,8 @@ defaultPrinterOpts =
       poDiffFriendlyImportExport = pure True,
       poRespectful = pure True,
       poHaddockStyle = pure HaddockMultiLine,
-      poNewlinesBetweenDecls = pure 1
+      poNewlinesBetweenDecls = pure 1,
+      poConsistentLet = pure False
     }
 
 -- | Fill the field values that are 'Nothing' in the first argument
@@ -192,7 +195,8 @@ fillMissingPrinterOpts p1 p2 =
       poDiffFriendlyImportExport = fillField poDiffFriendlyImportExport,
       poRespectful = fillField poRespectful,
       poHaddockStyle = fillField poHaddockStyle,
-      poNewlinesBetweenDecls = fillField poNewlinesBetweenDecls
+      poNewlinesBetweenDecls = fillField poNewlinesBetweenDecls,
+      poConsistentLet = fillField poConsistentLet
     }
   where
     fillField :: (forall g. PrinterOpts g -> g a) -> f a

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -31,7 +31,8 @@ spec = do
             poDiffFriendlyImportExport = pure False,
             poRespectful = pure False,
             poHaddockStyle = pure HaddockSingleLine,
-            poNewlinesBetweenDecls = pure 1
+            poNewlinesBetweenDecls = pure 1,
+            poConsistentLet = pure False
           }
   sequence_ $ checkExample <$> [(ormoluOpts, "ormolu", ""), (defaultPrinterOpts, "fourmolu", "-four")] <*> es
 


### PR DESCRIPTION
This creates a new configuration option, `consistent-let`. When false, the existing ugly Ormolu layout is used for `let` statements:
```
e1 =
    let a = 1
        b = 2
     in c

e2 = do
    a
    let b = 1
        c = 2
    return d
```
When true, Fourmolu treats `let` consistently with `do`, `case`, and `\case`, allowing the keyword to hang, and indenting the bindings & body normally:
```
e1 = let
    a = 1
    b = 2
    in c

e2 = do
    a
    let
        b = 1
        c = 2
    return d
```
Note that this is still allowed, if there's only one binding:
```
e2 = do
    a
    let b = 1
    return d
```
