### PR TITLE
Fix regression with multiline record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Fixed regression in 0.5.0.0 with multiline tuples ([#162](https://github.com/fourmolu/fourmolu/pull/162))
+* Fixed regression in 0.5.0.0 with multiline record types ([#160](https://github.com/fourmolu/fourmolu/pull/160))
 * Add `import-export-comma-style` configuration to allow leading commas in module import/export lists
 
 ## Fourmolu 0.5.0.0

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -259,7 +259,7 @@ p_forallBndrs vis p tyvars =
 
 p_conDeclFields :: [LConDeclField GhcPs] -> R ()
 p_conDeclFields xs =
-  braces N $ sep commaDel (located' p_conDeclField) xs
+  braces N $ sep commaDel (sitcc . located' p_conDeclField) xs
 
 p_conDeclField :: ConDeclField GhcPs -> R ()
 p_conDeclField ConDeclField {..} = do
@@ -276,7 +276,7 @@ p_conDeclField ConDeclField {..} = do
   breakpoint
   sitcc . inci $ p_hsType (unLoc cd_fld_type)
   when (commaStyle == Leading) $
-    mapM_ ((newline >>) . p_hsDocString Caret False) cd_fld_doc
+    mapM_ (inciByFrac (-1) . (newline >>) . p_hsDocString Caret False) cd_fld_doc
 
 tyOpTree :: LHsType GhcPs -> OpTree (LHsType GhcPs) (LocatedN RdrName)
 tyOpTree (L _ (HsOpTy _ l op r)) =


### PR DESCRIPTION
Partially revert https://github.com/fourmolu/fourmolu/pull/124 (specifically, the removal of `sitcc`) to fix https://github.com/fourmolu/fourmolu/issues/145

Completely separate from whether it looks better or not, that change actually causes inconsistencies with different options. Some examples are below. TL;DR we should revert this for now to fix the inconsistencies, then we can make the trailing comment indentation configurable for aesthetic reasons

## Record field inconsistencies

With `--indentation=4`, `--comma-style=trailing` and `--comma-style=leading` will indent the two comments differently:

```console
$ stack exec -- fourmolu --indentation=4 --comma-style=trailing test.hs
newtype App a = App
    { unApp ::
        JobExecutorT
            ( ReaderT
                MyConfig
                (LoggingT IO)
            )
            a,
      -- | asfd
      a :: Int,
      -- | asdf
      b :: Bool
    }

$ stack exec -- fourmolu --indentation=4 --comma-style=leading test.hs
newtype App a = App
    { unApp ::
        JobExecutorT
            ( ReaderT
                MyConfig
                (LoggingT IO)
            )
            a
    , a :: Int
    -- ^ asfd
    , b :: Bool
    -- ^ asdf
    }
```
But _**in addition to this**_, using `--indentation=2`, it also causes multiline types to be deindented (note `JobExecutorT` being deindented after `unApp` with `--comma-style=leading`):
```console
$ stack exec -- fourmolu --indentation=2 --comma-style=trailing test.hs
newtype App a = App
  { unApp ::
      JobExecutorT
        ( ReaderT
            MyConfig
            (LoggingT IO)
        )
        a,
    -- | asfd
    a :: Int,
    -- | asdf
    b :: Bool
  }

$ stack exec -- fourmolu --indentation=2 --comma-style=leading test.hs
newtype App a = App
  { unApp ::
    JobExecutorT
      ( ReaderT
          MyConfig
          (LoggingT IO)
      )
      a
  , a :: Int
  -- ^ asfd
  , b :: Bool
  -- ^ asdf
  }
```