### PR TITLE
Pin GHC 9.2.1

### DIFF
--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -1,5 +1,5 @@
 resolver: nightly-2022-03-03
-compiler: ghc-9.2
+compiler: ghc-9.2.1
 
 extra-deps:
   - base-compat-0.12.1


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/fourmolu/fourmolu/176/workflows/43180fe7-9782-424b-82c3-4d2a1f66b530/jobs/663

Fix failure, due to GHC 9.2.2 being released a week ago, we need to pin GHC 9.2.1 to match the version of ghc-lib-parser-9.2.1