### PR TITLE
Add --quiet flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add `--quiet` flag to make the output quieter
+
 ## Fourmolu 0.6.0.0
 
 * Fixed regression in 0.5.0.0 with multiline tuples ([#162](https://github.com/fourmolu/fourmolu/pull/162))

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -164,6 +164,8 @@ formatOne CabalDefaultExtensionsOpts {..} mode reqSourceType rawConfig mpath =
 data Opts = Opts
   { -- | Mode of operation
     optMode :: !Mode,
+    -- | Whether to make the output quieter
+    optQuiet :: !Bool,
     -- | Ormolu 'Config'
     optConfig :: !(Config RegionIndices),
     -- | Options for respecting default-extensions from .cabal files
@@ -244,6 +246,11 @@ optsParser =
                 help "Mode of operation: 'stdout' (the default), 'inplace', or 'check'"
               ]
         )
+    <*> (switch . mconcat)
+      [ long "quiet",
+        short 'q',
+        help "Make output quieter"
+      ]
     <*> configParser
     <*> cabalDefaultExtensionsParser
     <*> sourceTypeParser
@@ -494,7 +501,8 @@ mkConfig path Opts {..} = do
   filePrinterOpts <-
     loadConfigFile path >>= \case
       ConfigLoaded f po -> do
-        hPutStrLn stderr $ "Loaded config from: " <> f
+        unless optQuiet $
+          hPutStrLn stderr $ "Loaded config from: " <> f
         printDebug $ show po
         return $ Just po
       ConfigParseError f (_pos, err) -> do


### PR DESCRIPTION
Supercedes #101, fixes #110

Solves the immediate issue of suppressing the "Loaded config from: ..." output. Long-term, we should probably think about whether we want to consolidate `optQuiet` and `cfgDebug` into a single "log level" field (but keeping them separate cli flags); but maybe we want to keep ormolu-owned logging separate from fourmolu-owned logging?