### PR TITLE
Support consecutive newlines in multiline haddocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - 'infixr 5 #'
   ```
 * Fixed issue with `import-export-comma-style` for multiline import/export elements ([#187](https://github.com/fourmolu/fourmolu/pull/187))
+* Multiline haddock comments with consecutive empty newlines will no longer report an "AST differs" error ([#172](https://github.com/fourmolu/fourmolu/issues/172))
 
 #### Ormolu 0.5.0.0
 

--- a/data/fourmolu/haddock-style/input.hs
+++ b/data/fourmolu/haddock-style/input.hs
@@ -17,3 +17,13 @@ This is a multiline
 function haddock
 -}
 multi2 :: Int
+
+-- | This is a haddock
+--
+-- with two consecutive newlines
+--
+--
+-- https://github.com/fourmolu/fourmolu/issues/172
+foo :: Int
+foo = 42
+

--- a/data/fourmolu/haddock-style/output-HaddockMultiLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockMultiLine.hs
@@ -19,3 +19,13 @@ This is a multiline
 function haddock
 -}
 multi2 :: Int
+
+{- | This is a haddock
+
+ with two consecutive newlines
+
+
+ https://github.com/fourmolu/fourmolu/issues/172
+-}
+foo :: Int
+foo = 42

--- a/data/fourmolu/haddock-style/output-HaddockSingleLine.hs
+++ b/data/fourmolu/haddock-style/output-HaddockSingleLine.hs
@@ -16,3 +16,12 @@ multi1 :: Int
 --This is a multiline
 --function haddock
 multi2 :: Int
+
+-- | This is a haddock
+--
+-- with two consecutive newlines
+--
+--
+-- https://github.com/fourmolu/fourmolu/issues/172
+foo :: Int
+foo = 42

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -161,16 +161,23 @@ p_hsDocString hstyle needsNewline (L l str) = do
           ]
 
   let txt' x = unless (T.null x) (txt x)
-      body s = do
-        sequence_ $ intersperse (newline >> s) $ map txt' docLines
+      body s = sequence_ $ intersperse s $ map txt' docLines
 
   if useSingleLineComments
     then do
       txt $ "-- " <> haddockDelim
-      body $ txt "--"
+      body $ newline >> txt "--"
     else do
       txt $ "{- " <> haddockDelim
-      body $ pure ()
+      -- 'newline' doesn't allow multiple blank newlines, which changes the comment
+      -- if the user writes a comment with multiple newlines. So we have to do this
+      -- to force the printer to output a newline. The HaddockSingleLine branch
+      -- doesn't have this problem because each newline has at least "--".
+      --
+      -- 'newline' also takes indentation into account, but since multiline comments
+      -- are never used in an indented context (see useSingleLineComments), this is
+      -- safe
+      body $ txt "\n"
       newline
       txt "-}"
 

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -162,19 +162,14 @@ p_hsDocString hstyle needsNewline (L l str) = do
 
   let txt' x = unless (T.null x) (txt x)
       body s = do
-        txt $ case hstyle of
-          Pipe -> " |"
-          Caret -> " ^"
-          Asterisk n -> " " <> T.replicate n "*"
-          Named name -> " $" <> T.pack name
         sequence_ $ intersperse (newline >> s) $ map txt' docLines
 
   if useSingleLineComments
     then do
-      txt "--"
+      txt $ "-- " <> haddockDelim
       body $ txt "--"
     else do
-      txt "{-"
+      txt $ "{- " <> haddockDelim
       body $ pure ()
       newline
       txt "-}"
@@ -183,6 +178,12 @@ p_hsDocString hstyle needsNewline (L l str) = do
   traverse_ (setSpanMark . HaddockSpan hstyle) mSrcSpan
   where
     docLines = splitDocString str
+    haddockDelim =
+      case hstyle of
+        Pipe -> "|"
+        Caret -> "^"
+        Asterisk n -> T.replicate n "*"
+        Named name -> "$" <> T.pack name
     getSrcSpan = \case
       -- It's often the case that the comment itself doesn't have a span
       -- attached to it and instead its location can be obtained from

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -148,7 +148,6 @@ p_hsDocString hstyle needsNewline (L l str) = do
   -- Make sure the Haddock is separated by a newline from other comments.
   when goesAfterComment newline
   let txt' x = unless (T.null x) (txt x)
-      docLines = splitDocString str
       body s = do
         txt $ case hstyle of
           Pipe -> " |"
@@ -161,24 +160,20 @@ p_hsDocString hstyle needsNewline (L l str) = do
       HaddockSingleLine -> pure True
       -- Use multiple single-line comments when the whole comment is indented
       HaddockMultiLine -> maybe False ((> 1) . srcSpanStartCol) <$> getSrcSpan l
-  if single
+  if single || length docLines <= 1
     then do
       txt "--"
       body $ txt "--"
-    else
-      if length docLines <= 1
-        then do
-          txt "--"
-          body $ pure ()
-        else do
-          txt "{-"
-          body $ pure ()
-          newline
-          txt "-}"
+    else do
+      txt "{-"
+      body $ pure ()
+      newline
+      txt "-}"
 
   when needsNewline newline
   getSrcSpan l >>= mapM_ (setSpanMark . HaddockSpan hstyle)
   where
+    docLines = splitDocString str
     getSrcSpan = \case
       -- It's often the case that the comment itself doesn't have a span
       -- attached to it and instead its location can be obtained from


### PR DESCRIPTION
Fixes #172 and adds a test. Blocked on #169

@georgefst would be great to get #169 merged so that we can start merging PRs using the new test framework