### PR TITLE
Improve region tests

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -115,10 +115,9 @@ Fourmolu aims to continue merging upstream changes in Ormolu. Whenever Ormolu ma
 1. Add Ormolu as an upstream remote: `git remote add ormolu git@github.com:tweag/ormolu`
 1. Check out a new branch: `git switch -c merge-ormolu`
 1. Pull Ormolu's git history: `git fetch ormolu --no-tags`
-1. Find the commit corresponding to the new Ormolu version and merge it: `git merge <commit>`
+1. Find the commit corresponding to the new Ormolu version and merge it: `git merge <commit> -m 'Merge ormolu-X.Y.Z'`
 1. (Recommended) Switch to diff3 conflicts: `git checkout --conflict=diff3`. This provides more context that might be helpful for resolving conflicts. See [docs](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_checking_out_conflicts).
 1. Resolve conflicts + finish merge: `git merge --continue`
-    * Rewrite the default commit message to "Merge ormolu-X.Y.Z"
 1. Run tests to ensure everything works well: `stack test`
 
 ### Resolving conflicts

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -175,7 +175,6 @@ test-suite region-tests
 
     default-language:   Haskell2010
     build-depends:
-        fourmolu,
         base >=4.14 && <5.0,
         directory >=1.3 && <1.4,
         hspec >=2.0 && <3.0,

--- a/region-tests/Main.hs
+++ b/region-tests/Main.hs
@@ -15,7 +15,7 @@ main = hspec $
           readProcess fourmoluExe $
             ["region-tests/src.hs", "--check-idempotence"] ++ testArgs
         expected <- readFile $ "region-tests/" ++ testExpectedFileName
-        expected `shouldBe` actual
+        actual `shouldBe` expected
 
 data Test = Test
   { testLabel :: String,


### PR DESCRIPTION
The test suite doesn't import `fourmolu`, so it doesn't need it as a dependency. However, running tests does require the executable, so one needs to remember to explicitly build the executable. Keeping `fourmolu` as a dependency doesn't help with this; the dependency only specifies the library as a dependency, not the executable, and Stack will only build the executable the first time.

Also show better output if the command fails