### PR TITLE
Use better YAML library

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ $ stack install fourmolu
 ## Building from source
 
 ```console
-$ cabal build
-$ stack build
+$ cabal build -fdev
+$ stack build --flag fourmolu:dev
 ```
+
+The `dev` flag may be omitted in your local workflow as you work, but CI may not pass if you only build without the `dev` flag.
 
 ## Usage
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -25,6 +25,7 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import Data.Version (showVersion)
+import qualified Data.Yaml as Yaml
 import Development.GitRev
 import Options.Applicative
 import Ormolu
@@ -547,12 +548,11 @@ mkConfig path Opts {..} = do
             "Loaded config from: " <> f
         printDebug $ show cfg
         return $ Just cfg
-      ConfigParseError f (_pos, err) -> do
-        -- we ignore '_pos' due to the note on 'Data.YAML.Aeson.decode1'
+      ConfigParseError f e -> do
         hPutStrLn stderr $
           unlines
             [ "Failed to load " <> f <> ":",
-              "  " <> err
+              Yaml.prettyPrintParseException e
             ]
         exitWith $ ExitFailure 400
       ConfigNotFound searchDirs -> do

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -113,8 +113,7 @@ library
         text >=0.2 && <3.0,
         th-lift-instances >=0.1 && <0.2,
         -- fourmolu-only deps
-        HsYAML >=0.2 && <0.3,
-        HsYAML-aeson >=0.2 && <0.3
+        yaml >=0.11.6.0 && <1
 
     mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
 
@@ -149,6 +148,7 @@ executable fourmolu
         text >=0.2 && <3.0,
         -- fourmolu-only deps
         directory >=1.3.3 && <1.4,
+        yaml >=0.11.6.0 && <1,
         fourmolu
 
     if flag(dev)

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -106,14 +106,15 @@ library
         exceptions >=0.6 && <0.11,
         filepath >=1.2 && <1.5,
         ghc-lib-parser >=9.2 && <9.3,
-        HsYAML >=0.2 && <0.3,
-        HsYAML-aeson >=0.2 && <0.3,
         megaparsec >=9.0,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
         template-haskell,
         text >=0.2 && <3.0,
-        th-lift-instances >=0.1 && <0.2
+        th-lift-instances >=0.1 && <0.2,
+        -- fourmolu-only deps
+        HsYAML >=0.2 && <0.3,
+        HsYAML-aeson >=0.2 && <0.3
 
     mixins:           ghc-lib-parser hiding (Language.Haskell.TH.Syntax)
 
@@ -139,15 +140,16 @@ executable fourmolu
     autogen-modules:  Paths_fourmolu
     default-language: Haskell2010
     build-depends:
-        fourmolu,
         base >=4.12 && <5.0,
         containers >=0.5 && <0.7,
-        directory >=1.3.3 && <1.4,
         filepath >=1.2 && <1.5,
         ghc-lib-parser >=9.2 && <9.3,
         gitrev >=1.3 && <1.4,
         optparse-applicative >=0.14 && <0.18,
-        text >=0.2 && <3.0
+        text >=0.2 && <3.0,
+        -- fourmolu-only deps
+        directory >=1.3.3 && <1.4,
+        fourmolu
 
     if flag(dev)
         ghc-options:
@@ -177,7 +179,6 @@ test-suite tests
 
     default-language:   Haskell2010
     build-depends:
-        fourmolu,
         QuickCheck >=2.14,
         base >=4.14 && <5.0,
         containers >=0.5 && <0.7,
@@ -190,7 +191,9 @@ test-suite tests
         path >=0.6 && <0.10,
         path-io >=1.4.2 && <2.0,
         temporary ^>=1.3,
-        text >=0.2 && <3.0
+        text >=0.2 && <3.0,
+        -- fourmolu-only deps
+        fourmolu
 
     if flag(dev)
         ghc-options: -Wall -Werror

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -45,14 +45,12 @@ import Data.Aeson
     (.!=),
     (.:?),
   )
-import qualified Data.ByteString.Lazy as BS
 import Data.Char (isLower)
 import Data.Functor.Identity (Identity (..))
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.YAML (Pos)
-import Data.YAML.Aeson (decode1)
+import qualified Data.Yaml as Yaml
 import GHC.Generics (Generic)
 import qualified GHC.Types.SrcLoc as GHC
 import Ormolu.Fixity (FixityMap)
@@ -303,15 +301,13 @@ loadConfigFile path = do
     Nothing -> return $ ConfigNotFound dirs
     Just file ->
       either (ConfigParseError file) (ConfigLoaded file)
-        . decode1
-        <$> BS.readFile file
+        <$> Yaml.decodeFileEither file
 
 -- | The result of calling 'loadConfigFile'.
 data ConfigFileLoadResult
   = ConfigLoaded FilePath FourmoluConfig
-  | ConfigParseError FilePath (Pos, String)
+  | ConfigParseError FilePath Yaml.ParseException
   | ConfigNotFound [FilePath]
-  deriving (Eq, Show)
 
 -- | Expected file name for YAML config.
 configFileName :: FilePath

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -33,18 +33,8 @@ module Ormolu.Config
   )
 where
 
-import Data.Aeson
-  ( FromJSON (..),
-    Value (Object),
-    camelTo2,
-    constructorTagModifier,
-    defaultOptions,
-    fieldLabelModifier,
-    genericParseJSON,
-    withObject,
-    (.!=),
-    (.:?),
-  )
+import Data.Aeson ((.!=), (.:?))
+import qualified Data.Aeson as Aeson
 import Data.Char (isLower)
 import Data.Functor.Identity (Identity (..))
 import qualified Data.Map.Strict as Map
@@ -223,11 +213,11 @@ data CommaStyle
   | Trailing
   deriving (Eq, Ord, Show, Generic, Bounded, Enum)
 
-instance FromJSON CommaStyle where
+instance Aeson.FromJSON CommaStyle where
   parseJSON =
-    genericParseJSON
-      defaultOptions
-        { constructorTagModifier = camelTo2 '-'
+    Aeson.genericParseJSON
+      Aeson.defaultOptions
+        { Aeson.constructorTagModifier = Aeson.camelTo2 '-'
         }
 
 data HaddockPrintStyle
@@ -235,11 +225,11 @@ data HaddockPrintStyle
   | HaddockMultiLine
   deriving (Eq, Ord, Show, Generic, Bounded, Enum)
 
-instance FromJSON HaddockPrintStyle where
+instance Aeson.FromJSON HaddockPrintStyle where
   parseJSON =
-    genericParseJSON
-      defaultOptions
-        { constructorTagModifier = drop (length ("haddock-" :: String)) . camelTo2 '-'
+    Aeson.genericParseJSON
+      Aeson.defaultOptions
+        { Aeson.constructorTagModifier = drop (length ("haddock-" :: String)) . Aeson.camelTo2 '-'
         }
 
 -- | Convert 'RegionIndices' into 'RegionDeltas'.
@@ -266,11 +256,11 @@ newtype DynOption = DynOption
 dynOptionToLocatedStr :: DynOption -> GHC.Located String
 dynOptionToLocatedStr (DynOption o) = GHC.L GHC.noSrcSpan o
 
-instance FromJSON PrinterOptsPartial where
+instance Aeson.FromJSON PrinterOptsPartial where
   parseJSON =
-    genericParseJSON
-      defaultOptions
-        { fieldLabelModifier = camelTo2 '-' . dropWhile isLower
+    Aeson.genericParseJSON
+      Aeson.defaultOptions
+        { Aeson.fieldLabelModifier = Aeson.camelTo2 '-' . dropWhile isLower
         }
 
 data FourmoluConfig = FourmoluConfig
@@ -279,9 +269,9 @@ data FourmoluConfig = FourmoluConfig
   }
   deriving (Eq, Show)
 
-instance FromJSON FourmoluConfig where
-  parseJSON = withObject "FourmoluConfig" $ \o -> do
-    cfgFilePrinterOpts <- parseJSON (Object o)
+instance Aeson.FromJSON FourmoluConfig where
+  parseJSON = Aeson.withObject "FourmoluConfig" $ \o -> do
+    cfgFilePrinterOpts <- Aeson.parseJSON (Aeson.Object o)
     rawFixities <- o .:? "fixities" .!= []
     cfgFileFixities <-
       case mapM parseFixityDeclaration rawFixities of

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -38,7 +38,7 @@ spec = do
       ciDynOpts `shouldBe` [DynOption "-XHaskell2010"]
     it "extracts correct dependencies from fourmolu.cabal (src/Ormolu/Config.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "fourmolu.cabal" "src/Ormolu/Config.hs"
-      ciDependencies `shouldBe` Set.fromList ["Cabal", "Diff", "HsYAML", "HsYAML-aeson", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "exceptions", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "template-haskell", "text", "th-lift-instances"]
+      ciDependencies `shouldBe` Set.fromList ["Cabal", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "bytestring", "containers", "directory", "dlist", "exceptions", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "syb", "template-haskell", "text", "th-lift-instances", "yaml"]
     it "extracts correct dependencies from fourmolu.cabal (tests/Ormolu/PrinterSpec.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "fourmolu.cabal" "tests/Ormolu/PrinterSpec.hs"
       ciDependencies `shouldBe` Set.fromList ["QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "fourmolu", "path", "path-io", "temporary", "text"]


### PR DESCRIPTION
`yaml` is more standard + has better error messages than `HsYAML`:
```yaml
# fourmolu.yaml
foo: 1
bar
```
```console
# HsYAML
Failed to load /Users/brandino/repos/fourmolu/fourmolu.yaml:
  Unexpected 'b'
```
```console
# yaml
Failed to load /Users/brandino/repos/fourmolu/fourmolu.yaml:
YAML parse exception at line 2, column 0,
while scanning a simple key:
could not find expected ':'
```
Plus some clean up commits