### PR TITLE
Check hackage token

### DIFF
--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -25,6 +25,12 @@ def main():
 
     version_name = f"v{version}"
 
+    # check inputs
+    if not hackage_token:
+        raise Exception(
+            "Hackage token is not provided (did you add a Secret of the form HACKAGE_TOKEN_<github username>?)"
+        )
+
     # ensure release files exist
     gh_release_files = [
         Path(bindir) / f"fourmolu-{version}-linux-x86_64",


### PR DESCRIPTION
Unfortunately, GitHub Actions will return an empty string if an expression fails, not an error.