### PR TITLE
Use import export comma option in commaDel'

### DIFF
--- a/data/examples/import/nested-explicit-imports-four-ie-out.hs
+++ b/data/examples/import/nested-explicit-imports-four-ie-out.hs
@@ -1,9 +1,9 @@
 import qualified MegaModule as M
     ( Either
     , Monad
-        ( return,
-        (>>),
-        (>>=)
+        ( return
+        , (>>)
+        , (>>=)
         )
     , (<<<)
     , (>>>)

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -73,6 +73,7 @@ module Ormolu.Printer.Combinators
     -- ** Placement
     Placement (..),
     placeHanging,
+    commaDelImportExport,
   )
 where
 
@@ -315,10 +316,16 @@ comma = txt ","
 
 -- | Delimiting combination with 'comma'. To be used with 'sep'.
 commaDel :: R ()
-commaDel =
-  getPrinterOpt poCommaStyle >>= \case
-    Leading -> breakpoint' >> comma >> space
-    Trailing -> comma >> breakpoint
+commaDel = getPrinterOpt poCommaStyle >>= commaDel'
+
+-- | Delimiting combination with 'comma' for import-export lists.
+commaDelImportExport :: R ()
+commaDelImportExport = getPrinterOpt poImportExportCommaStyle >>= commaDel'
+
+commaDel' :: CommaStyle -> R ()
+commaDel' = \case
+  Leading -> breakpoint' >> comma >> space
+  Trailing -> comma >> breakpoint
 
 -- | Print @=@. Do not use @'txt' "="@.
 equals :: R ()

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -100,7 +100,7 @@ p_lie encLayout relativePos = \case
     inci $ do
       let names :: [R ()]
           names = located' p_ieWrappedName <$> xs
-      parens' False . sep commaDel' sitcc $
+      parens' False . sep commaDelImportExport sitcc $
         case w of
           NoIEWildcard -> names
           IEWildcard n ->
@@ -177,13 +177,6 @@ attachRelativePos' = \case
     markLast [] = []
     markLast [x] = [(LastPos, x)]
     markLast (x : xs) = (MiddlePos, x) : markLast xs
-
--- | Delimiting combination with 'comma'. To be used with 'sep'.
-commaDel' :: R ()
-commaDel' =
-  getPrinterOpt poImportExportCommaStyle >>= \case
-    Leading -> breakpoint' >> comma >> space
-    Trailing -> comma >> breakpoint
 
 -- | Surround given entity by parentheses @(@ and @)@.
 parens' :: Bool -> R () -> R ()

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -178,13 +178,12 @@ attachRelativePos' = \case
     markLast [x] = [(LastPos, x)]
     markLast (x : xs) = (MiddlePos, x) : markLast xs
 
--- Unlike the versions in 'Ormolu.Printer.Combinators', these do not depend on
--- whether 'leadingCommas' is set. This is useful here is we choose to keep
--- import and export lists independent of that setting.
-
 -- | Delimiting combination with 'comma'. To be used with 'sep'.
 commaDel' :: R ()
-commaDel' = comma >> breakpoint
+commaDel' =
+  getPrinterOpt poImportExportCommaStyle >>= \case
+    Leading -> breakpoint' >> comma >> space
+    Trailing -> comma >> breakpoint
 
 -- | Surround given entity by parentheses @(@ and @)@.
 parens' :: Bool -> R () -> R ()


### PR DESCRIPTION
`commaDel'` now checks the import export lists comma option. This makes nested list imports being formatted similarly to regular lists.
fixes #174 
cc @brandonchinn178 