### PR TITLE
Add option to format with Unicode syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Defaults are in bold.
 | `in-style`               | `left-align`, **`right-align`**                       | How to align the `in` keyword with respect to `let`
 | `respectful`             | **`true`**, `false`                                   | Be less aggressive in reformatting input, e.g. keep empty lines in import list
 | `fixities`               | list of strings (**`[]`**)                           | See the "Language extensions, dependencies, and fixities" section below
+| `unicode`                | `always`, `detect`, `never`                           | Output Unicode syntax. With `detect` we output Unicode syntax exactly when the extension is seen to be enabled.
 
 For examples of each of these options, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/).
 
@@ -79,6 +80,7 @@ let-style: auto
 in-style: right-align
 respectful: true
 fixities: []
+unicode: never
 ```
 
 The configuration that most closely matches Ormolu's styling is:
@@ -96,6 +98,7 @@ let-style: inline
 in-style: right-align
 respectful: false
 fixities: []
+unicode: never
 ```
 
 Command-line options override options in a configuration file. Run `fourmolu --help` to see all options.

--- a/changelog.d/unicode.md
+++ b/changelog.d/unicode.md
@@ -1,0 +1,3 @@
+Add `unicode` setting.
+* Pull request: [#206](https://github.com/fourmolu/fourmolu/pull/206).
+* The default value is `never`, it has the same behaviour as before.

--- a/data/fourmolu/unicode-syntax/input.hs
+++ b/data/fourmolu/unicode-syntax/input.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE Arrows #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module UnicodeExample where
+
+import Control.Arrow
+import Data.Kind
+import Language.Haskell.TH (Exp, Quote)
+import Prelude hiding (elem)
+
+data T = MkT {foo :: Int}
+
+data Term a where
+    Lit :: Int -> Term Int
+    Succ :: Term Int -> Term Int
+    IsZero :: Term Int -> Term Bool
+    If :: Term Bool -> Term a -> Term a -> Term a
+    Pair :: Term a -> Term b -> Term (a, b)
+
+newtype Swizzle = MkSwizzle (forall a. Ord a => [a] -> [a])
+
+data family GMap k :: Type -> Type
+
+data instance GMap (Either a b) v = GMapEither (GMap a v) (GMap b v)
+
+type family F a where
+    F Int = Double
+    F Bool = Char
+    F a = String
+
+type family Id a = r | r -> a
+
+type instance Id Int = Int
+
+type instance Id Bool = Bool
+
+type family Elem c :: Type
+
+type instance Elem [e] = e
+
+data T1 a = MkT1 a
+
+construct :: a %1 -> T1 a
+construct x = MkT1 x
+
+deconstruct :: T1 a %1 -> a
+deconstruct (MkT1 x) = x
+
+pattern HeadC x <- x : xs
+    where
+        HeadC x = [x]
+
+pattern Point :: Int -> Int -> (Int, Int)
+pattern Point {x, y} = (x, y)
+
+class (Monad m, Monad (t m)) => Transform t m where
+    lift :: m a -> (t m) a
+
+data Tree a = Leaf a | Branch (Tree a) (Tree a)
+
+instance (Eq a) => Eq (Tree a) where
+    Leaf a == Leaf b = a == b
+    (Branch l1 r1) == (Branch l2 r2) = (l1 == l2) && (r1 == r2)
+    _ == _ = False
+
+add1 :: Quote m => Int -> m Exp
+add1 x = [|x + 1|]
+
+monad = do
+    putStr "x: "
+    l <- getLine
+    return (words l)
+
+arrow f g h = proc x -> do
+    y <- f -< x + 1
+    g -< 2 * y
+    let z = x + y
+    t <- h -< x * z
+    returnA -< t + z
+
+elem :: (Eq a) => a -> [a] -> Bool
+x `elem` [] = False
+x `elem` (y : ys) = x == y || (x `elem` ys)
+
+h :: (forall a. a -> a) -> (Bool, Char)
+h f = (f True, f 'c')

--- a/data/fourmolu/unicode-syntax/output-UnicodeAlways.hs
+++ b/data/fourmolu/unicode-syntax/output-UnicodeAlways.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE Arrows #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module UnicodeExample where
+
+import Control.Arrow
+import Data.Kind
+import Language.Haskell.TH (Exp, Quote)
+import Prelude hiding (elem)
+
+data T = MkT {foo ∷ Int}
+
+data Term a where
+    Lit ∷ Int → Term Int
+    Succ ∷ Term Int → Term Int
+    IsZero ∷ Term Int → Term Bool
+    If ∷ Term Bool → Term a → Term a → Term a
+    Pair ∷ Term a → Term b → Term (a, b)
+
+newtype Swizzle = MkSwizzle (∀ a. Ord a ⇒ [a] → [a])
+
+data family GMap k ∷ Type → Type
+
+data instance GMap (Either a b) v = GMapEither (GMap a v) (GMap b v)
+
+type family F a where
+    F Int = Double
+    F Bool = Char
+    F a = String
+
+type family Id a = r | r → a
+
+type instance Id Int = Int
+
+type instance Id Bool = Bool
+
+type family Elem c ∷ Type
+
+type instance Elem [e] = e
+
+data T1 a = MkT1 a
+
+construct ∷ a ⊸ T1 a
+construct x = MkT1 x
+
+deconstruct ∷ T1 a ⊸ a
+deconstruct (MkT1 x) = x
+
+pattern HeadC x ← x : xs
+    where
+        HeadC x = [x]
+
+pattern Point ∷ Int → Int → (Int, Int)
+pattern Point{x, y} = (x, y)
+
+class (Monad m, Monad (t m)) ⇒ Transform t m where
+    lift ∷ m a → (t m) a
+
+data Tree a = Leaf a | Branch (Tree a) (Tree a)
+
+instance (Eq a) ⇒ Eq (Tree a) where
+    Leaf a == Leaf b = a == b
+    (Branch l1 r1) == (Branch l2 r2) = (l1 == l2) && (r1 == r2)
+    _ == _ = False
+
+add1 ∷ Quote m ⇒ Int → m Exp
+add1 x = [|x + 1|]
+
+monad = do
+    putStr "x: "
+    l ← getLine
+    return (words l)
+
+arrow f g h = proc x → do
+    y ← f ⤙ x + 1
+    g ⤙ 2 * y
+    let z = x + y
+    t ← h ⤙ x * z
+    returnA ⤙ t + z
+
+elem ∷ (Eq a) ⇒ a → [a] → Bool
+x `elem` [] = False
+x `elem` (y : ys) = x == y || (x `elem` ys)
+
+h ∷ (∀ a. a → a) → (Bool, Char)
+h f = (f True, f 'c')

--- a/data/fourmolu/unicode-syntax/output-UnicodeDetect.hs
+++ b/data/fourmolu/unicode-syntax/output-UnicodeDetect.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE Arrows #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module UnicodeExample where
+
+import Control.Arrow
+import Data.Kind
+import Language.Haskell.TH (Exp, Quote)
+import Prelude hiding (elem)
+
+data T = MkT {foo ∷ Int}
+
+data Term a where
+    Lit ∷ Int → Term Int
+    Succ ∷ Term Int → Term Int
+    IsZero ∷ Term Int → Term Bool
+    If ∷ Term Bool → Term a → Term a → Term a
+    Pair ∷ Term a → Term b → Term (a, b)
+
+newtype Swizzle = MkSwizzle (∀ a. Ord a ⇒ [a] → [a])
+
+data family GMap k ∷ Type → Type
+
+data instance GMap (Either a b) v = GMapEither (GMap a v) (GMap b v)
+
+type family F a where
+    F Int = Double
+    F Bool = Char
+    F a = String
+
+type family Id a = r | r → a
+
+type instance Id Int = Int
+
+type instance Id Bool = Bool
+
+type family Elem c ∷ Type
+
+type instance Elem [e] = e
+
+data T1 a = MkT1 a
+
+construct ∷ a ⊸ T1 a
+construct x = MkT1 x
+
+deconstruct ∷ T1 a ⊸ a
+deconstruct (MkT1 x) = x
+
+pattern HeadC x ← x : xs
+    where
+        HeadC x = [x]
+
+pattern Point ∷ Int → Int → (Int, Int)
+pattern Point{x, y} = (x, y)
+
+class (Monad m, Monad (t m)) ⇒ Transform t m where
+    lift ∷ m a → (t m) a
+
+data Tree a = Leaf a | Branch (Tree a) (Tree a)
+
+instance (Eq a) ⇒ Eq (Tree a) where
+    Leaf a == Leaf b = a == b
+    (Branch l1 r1) == (Branch l2 r2) = (l1 == l2) && (r1 == r2)
+    _ == _ = False
+
+add1 ∷ Quote m ⇒ Int → m Exp
+add1 x = [|x + 1|]
+
+monad = do
+    putStr "x: "
+    l ← getLine
+    return (words l)
+
+arrow f g h = proc x → do
+    y ← f ⤙ x + 1
+    g ⤙ 2 * y
+    let z = x + y
+    t ← h ⤙ x * z
+    returnA ⤙ t + z
+
+elem ∷ (Eq a) ⇒ a → [a] → Bool
+x `elem` [] = False
+x `elem` (y : ys) = x == y || (x `elem` ys)
+
+h ∷ (∀ a. a → a) → (Bool, Char)
+h f = (f True, f 'c')

--- a/data/fourmolu/unicode-syntax/output-UnicodeNever.hs
+++ b/data/fourmolu/unicode-syntax/output-UnicodeNever.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE Arrows #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module UnicodeExample where
+
+import Control.Arrow
+import Data.Kind
+import Language.Haskell.TH (Exp, Quote)
+import Prelude hiding (elem)
+
+data T = MkT {foo :: Int}
+
+data Term a where
+    Lit :: Int -> Term Int
+    Succ :: Term Int -> Term Int
+    IsZero :: Term Int -> Term Bool
+    If :: Term Bool -> Term a -> Term a -> Term a
+    Pair :: Term a -> Term b -> Term (a, b)
+
+newtype Swizzle = MkSwizzle (forall a. Ord a => [a] -> [a])
+
+data family GMap k :: Type -> Type
+
+data instance GMap (Either a b) v = GMapEither (GMap a v) (GMap b v)
+
+type family F a where
+    F Int = Double
+    F Bool = Char
+    F a = String
+
+type family Id a = r | r -> a
+
+type instance Id Int = Int
+
+type instance Id Bool = Bool
+
+type family Elem c :: Type
+
+type instance Elem [e] = e
+
+data T1 a = MkT1 a
+
+construct :: a %1 -> T1 a
+construct x = MkT1 x
+
+deconstruct :: T1 a %1 -> a
+deconstruct (MkT1 x) = x
+
+pattern HeadC x <- x : xs
+    where
+        HeadC x = [x]
+
+pattern Point :: Int -> Int -> (Int, Int)
+pattern Point{x, y} = (x, y)
+
+class (Monad m, Monad (t m)) => Transform t m where
+    lift :: m a -> (t m) a
+
+data Tree a = Leaf a | Branch (Tree a) (Tree a)
+
+instance (Eq a) => Eq (Tree a) where
+    Leaf a == Leaf b = a == b
+    (Branch l1 r1) == (Branch l2 r2) = (l1 == l2) && (r1 == r2)
+    _ == _ = False
+
+add1 :: Quote m => Int -> m Exp
+add1 x = [|x + 1|]
+
+monad = do
+    putStr "x: "
+    l <- getLine
+    return (words l)
+
+arrow f g h = proc x -> do
+    y <- f -< x + 1
+    g -< 2 * y
+    let z = x + y
+    t <- h -< x * z
+    returnA -< t + z
+
+elem :: (Eq a) => a -> [a] -> Bool
+x `elem` [] = False
+x `elem` (y : ys) = x == y || (x `elem` ys)
+
+h :: (forall a. a -> a) -> (Bool, Char)
+h f = (f True, f 'c')

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -11,3 +11,4 @@ let-style: inline
 in-style: right-align
 respectful: false
 fixities: []
+unicode: never

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -230,6 +230,7 @@ overFieldsM f $(unpackFieldsWithSuffix 'PrinterOpts "0") = do
   poLetStyle <- f poLetStyle0
   poInStyle <- f poInStyle0
   poRespectful <- f poRespectful0
+  poUnicode <- f poUnicode0
   return PrinterOpts {..}
 
 defaultPrinterOpts :: PrinterOptsTotal
@@ -369,6 +370,14 @@ printerOptsMeta =
             metaPlaceholder = "BOOL",
             metaHelp = "Give the programmer more choice on where to insert blank lines",
             metaDefault = True
+          },
+      poUnicode =
+        PrinterOptsFieldMeta
+          { metaName = "unicode",
+            metaGetField = poUnicode,
+            metaPlaceholder = "UNICODE",
+            metaHelp = printf "Output Unicode syntax (choices: %s)" (showAllValues unicodePreferenceMap),
+            metaDefault = UnicodeNever
           }
     }
 
@@ -449,6 +458,15 @@ inStyleMap =
       ]
    )
 
+unicodePreferenceMap :: BijectiveMap Unicode
+unicodePreferenceMap =
+  $( mkBijectiveMap
+      [ ('UnicodeDetect, "detect"),
+        ('UnicodeAlways, "always"),
+        ('UnicodeNever, "never")
+      ]
+   )
+
 instance PrinterOptsFieldType CommaStyle where
   parseJSON = parseJSONWith commaStyleMap "CommaStyle"
   parseText = parseTextWith commaStyleMap
@@ -478,6 +496,11 @@ instance PrinterOptsFieldType InStyle where
   parseJSON = parseJSONWith inStyleMap "InStyle"
   parseText = parseTextWith inStyleMap
   showText = show . showTextWith inStyleMap
+
+instance PrinterOptsFieldType Unicode where
+  parseJSON = parseJSONWith unicodePreferenceMap "UnicodePreference"
+  parseText = parseTextWith unicodePreferenceMap
+  showText = show . showTextWith unicodePreferenceMap
 
 ----------------------------------------------------------------------------
 -- BijectiveMap helpers

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -9,6 +9,7 @@ module Ormolu.Config.Types
     ImportExportStyle (..),
     LetStyle (..),
     InStyle (..),
+    Unicode (..),
   )
 where
 
@@ -37,7 +38,9 @@ data PrinterOpts f = PrinterOpts
     -- | How to align in keyword
     poInStyle :: f InStyle,
     -- | Be less opinionated about spaces/newlines etc.
-    poRespectful :: f Bool
+    poRespectful :: f Bool,
+    -- | Output Unicode syntax
+    poUnicode :: f Unicode
   }
   deriving (Generic)
 
@@ -73,4 +76,10 @@ data LetStyle
 data InStyle
   = InLeftAlign
   | InRightAlign
+  deriving (Eq, Show, Enum, Bounded)
+
+data Unicode
+  = UnicodeDetect
+  | UnicodeAlways
+  | UnicodeNever
   deriving (Eq, Show, Enum, Bounded)

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -38,6 +38,7 @@ module Ormolu.Printer.Combinators
     breakpoint,
     breakpoint',
     getPrinterOpt,
+    whenUnicodeOtherwise,
 
     -- ** Formatting lists
     sep,
@@ -80,8 +81,10 @@ where
 import Control.Monad
 import Data.List (intersperse)
 import Data.Text (Text)
+import GHC.LanguageExtensions.Type
 import GHC.Types.SrcLoc
 import Ormolu.Config
+import Ormolu.Config.Types
 import Ormolu.Printer.Comments
 import Ormolu.Printer.Internal
 import Ormolu.Utils (HasSrcSpan (..))
@@ -164,6 +167,17 @@ breakpoint = vlayout space newline
 -- > breakpoint' = vlayout (return ()) newline
 breakpoint' :: R ()
 breakpoint' = vlayout (return ()) newline
+
+-- | Write the one text or the other depending on whether Unicode is enabled.
+whenUnicodeOtherwise :: Text -> Text -> R ()
+unicodeText `whenUnicodeOtherwise` asciiText = do
+  unicodePrinterOption <- getPrinterOpt poUnicode
+  unicodeExtensionIsEnabled <- isExtensionEnabled UnicodeSyntax
+  txt $ case unicodePrinterOption of
+    UnicodeDetect | unicodeExtensionIsEnabled -> unicodeText
+    UnicodeDetect | otherwise -> asciiText
+    UnicodeAlways -> unicodeText
+    UnicodeNever -> asciiText
 
 ----------------------------------------------------------------------------
 -- Formatting lists

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -64,6 +64,21 @@ module Ormolu.Printer.Combinators
     commaDel,
     commaDelImportExport,
     equals,
+    llarrowtail,
+    rrarrowtail,
+    darrow,
+    dcolon,
+    larrow,
+    larrowtail,
+    rarrow,
+    rarrowtail,
+    star,
+    forall,
+    oparenbar,
+    cparenbar,
+    openExpQuote,
+    closeQuote,
+    lolly,
 
     -- ** Stateful markers
     SpanMark (..),
@@ -349,6 +364,71 @@ commaDel' = \case
 -- | Print @=@. Do not use @'txt' "="@.
 equals :: R ()
 equals = interferingTxt "="
+
+-- The names of the following literals are from GHC's
+-- @compiler/GHC/Parser/Lexer.x@.
+
+llarrowtail,
+  rrarrowtail,
+  darrow,
+  dcolon,
+  larrow,
+  larrowtail,
+  rarrow,
+  rarrowtail,
+  star,
+  forall,
+  oparenbar,
+  cparenbar,
+  openExpQuote,
+  closeQuote,
+  lolly ::
+    R ()
+
+-- | Print @⤛@ or @-<<@ as appropriate.
+llarrowtail = "⤛" `whenUnicodeOtherwise` "-<<"
+
+-- | Print @⤜@ or @>>-@ as appropriate.
+rrarrowtail = "⤜" `whenUnicodeOtherwise` ">>-"
+
+-- | Print @⇒@ or @=>@ as appropriate.
+darrow = "⇒" `whenUnicodeOtherwise` "=>"
+
+-- | Print @∷@ or @::@ as appropriate.
+dcolon = "∷" `whenUnicodeOtherwise` "::"
+
+-- | Print @←@ or @<-@ as appropriate.
+larrow = "←" `whenUnicodeOtherwise` "<-"
+
+-- | Print @⤙@ or @-<@ as appropriate.
+larrowtail = "⤙" `whenUnicodeOtherwise` "-<"
+
+-- | Print @→@ or @->@ as appropriate.
+rarrow = "→" `whenUnicodeOtherwise` "->"
+
+-- | Print @⤚@ or @>-@ as appropriate.
+rarrowtail = "⤚" `whenUnicodeOtherwise` ">-"
+
+-- | Print @★@ or @*@ as appropriate.
+star = "★" `whenUnicodeOtherwise` "*"
+
+-- | Print @∀@ or @forall@ as appropriate.
+forall = "∀" `whenUnicodeOtherwise` "forall"
+
+-- | Print @⦇@ or @(|@ as appropriate.
+oparenbar = "⦇" `whenUnicodeOtherwise` "(|"
+
+-- | Print @⦈@ or @|)@ as appropriate.
+cparenbar = "⦈" `whenUnicodeOtherwise` "|)"
+
+-- | Print @⟦@ or @[|@ as appropriate.
+openExpQuote = "⟦" `whenUnicodeOtherwise` "[|"
+
+-- | Print @⟧@ or @|]@ as appropriate.
+closeQuote = "⟧" `whenUnicodeOtherwise` "|]"
+
+-- | Print @⊸@ or @%1 ->@ as appropriate.
+lolly = "⊸" `whenUnicodeOtherwise` "%1 ->"
 
 ----------------------------------------------------------------------------
 -- Placement

--- a/src/Ormolu/Printer/Meat/Declaration/Class.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Class.hs
@@ -78,7 +78,7 @@ p_classContext :: LHsContext GhcPs -> R ()
 p_classContext ctx = unless (null (unLoc ctx)) $ do
   located ctx p_hsContext
   space
-  txt "=>"
+  darrow
   breakpoint
 
 p_classFundeps :: [LHsFunDep GhcPs] -> R ()
@@ -97,7 +97,7 @@ p_funDep :: FunDep GhcPs -> R ()
 p_funDep (FunDep _ before after) = do
   sep space p_rdrName before
   space
-  txt "->"
+  rarrow
   space
   sep space p_rdrName after
 

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -66,7 +66,7 @@ p_dataDecl style name tpats fixity HsDataDefn {..} = do
           (p_lhsTypeArg <$> tpats)
       forM_ dd_kindSig $ \k -> do
         space
-        txt "::"
+        dcolon
         breakpoint
         inci $ located k p_hsType
   let gadt = isJust dd_kindSig || any (isGadt . unLoc) dd_cons
@@ -193,7 +193,7 @@ p_lhsContext = \case
   ctx -> do
     located ctx p_hsContext
     space
-    txt "=>"
+    darrow
     breakpoint
 
 isGadt :: ConDecl GhcPs -> Bool

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -133,7 +133,7 @@ p_specSig name ts InlinePragma {..} = pragmaBraces $ do
   space
   p_rdrName name
   space
-  txt "::"
+  dcolon
   breakpoint
   inci $ sep commaDel (located' p_hsSigType) ts
 
@@ -203,7 +203,7 @@ p_completeSig cs' mty =
       sep commaDel p_rdrName cs
       forM_ mty $ \ty -> do
         space
-        txt "::"
+        dcolon
         breakpoint
         inci (p_rdrName ty)
 

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -75,7 +75,7 @@ p_injectivityAnn (InjectivityAnn _ a bs) = do
   space
   p_rdrName a
   space
-  txt "->"
+  rarrow
   space
   sep space p_rdrName bs
 

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -273,7 +273,7 @@ p_match' placer render style isInfix strictness m_pats GRHSs {..} = do
         Function _ -> space >> inci equals
         PatternBind -> space >> inci equals
         s | isCase s && hasGuards -> return ()
-        _ -> space >> txt "->"
+        _ -> space >> rarrow
     switchLayout [patGrhssSpan] $
       placeHanging placement p_body
     inci p_where
@@ -301,7 +301,7 @@ p_grhs' parentPlacement placer render style (GRHS _ guards body) =
       space
       inci $ case style of
         EqualSign -> equals
-        RightArrow -> txt "->"
+        RightArrow -> rarrow
       -- If we have a sequence of guards and it is placed in the normal way,
       -- then we indent one level more for readability. Otherwise (all
       -- guards are on the same line) we do not need to indent, as it would
@@ -333,10 +333,10 @@ p_hsCmd' s = \case
     breakpoint
     inci $ do
       case (arrType, rightToLeft) of
-        (HsFirstOrderApp, True) -> txt "-<"
-        (HsHigherOrderApp, True) -> txt "-<<"
-        (HsFirstOrderApp, False) -> txt ">-"
-        (HsHigherOrderApp, False) -> txt ">>-"
+        (HsFirstOrderApp, True) -> larrowtail
+        (HsHigherOrderApp, True) -> llarrowtail
+        (HsFirstOrderApp, False) -> rarrowtail
+        (HsHigherOrderApp, False) -> rrarrowtail
       placeHanging (exprPlacement (unLoc input)) $
         located r p_hsExpr
   HsCmdArrForm _ form Prefix _ cmds -> banana s $ do
@@ -422,7 +422,7 @@ p_stmt' placer render = \case
   BindStmt _ p f@(getLocA -> l) -> do
     located p p_pat
     space
-    txt "<-"
+    larrow
     let loc = getLocA p
         placement
           | isOneLineSpan (mkSrcSpan (srcSpanEnd loc) (srcSpanStart l)) = placer (unLoc f)
@@ -853,7 +853,7 @@ p_hsExpr' s = \case
       breakpoint
       inci (p_pat x)
       breakpoint
-    txt "->"
+    rarrow
     placeHanging (cmdTopPlacement (unLoc e)) $
       located e (p_hsCmdTop N)
   HsStatic _ e -> do
@@ -878,7 +878,7 @@ p_patSynBind PSB {..} = do
         case psb_dir of
           Unidirectional ->
             switchLayout pattern_def_spans $ do
-              txt "<-"
+              larrow
               breakpoint
               located psb_def p_pat
           ImplicitBidirectional ->
@@ -888,7 +888,7 @@ p_patSynBind PSB {..} = do
               located psb_def p_pat
           ExplicitBidirectional mgroup -> do
             switchLayout pattern_def_spans $ do
-              txt "<-"
+              larrow
               breakpoint
               located psb_def p_pat
             breakpoint
@@ -1144,7 +1144,7 @@ p_pat = \case
   ViewPat _ expr pat -> sitcc $ do
     located expr p_hsExpr
     space
-    txt "->"
+    rarrow
     breakpoint
     inci (located pat p_pat)
   SplicePat _ splice -> p_hsSplice splice
@@ -1201,7 +1201,7 @@ p_hsSplice = \case
     -- QuasiQuoters often rely on precise custom strings. We cannot do any
     -- formatting here without potentially breaking someone's code.
     atom str
-    txt "|]"
+    closeQuote
   HsSpliced {} -> notImplemented "HsSpliced"
 
 p_hsSpliceTH ::
@@ -1251,7 +1251,7 @@ p_hsBracket epAnn = \case
       inci $ do
         dontUseBraces body
         breakpoint'
-        txt "|]"
+        closeQuote
     -- With StarIsType, type and declaration brackets might end with a *,
     -- so we have to insert a space in the end to prevent the (mis)parsing
     -- of an (*|) operator.

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1201,7 +1201,7 @@ p_hsSplice = \case
     -- QuasiQuoters often rely on precise custom strings. We cannot do any
     -- formatting here without potentially breaking someone's code.
     atom str
-    closeQuote
+    txt "|]"
   HsSpliced {} -> notImplemented "HsSpliced"
 
 p_hsSpliceTH ::
@@ -1251,7 +1251,7 @@ p_hsBracket epAnn = \case
       inci $ do
         dontUseBraces body
         breakpoint'
-        closeQuote
+        txt "|]"
     -- With StarIsType, type and declaration brackets might end with a *,
     -- so we have to insert a space in the end to prevent the (mis)parsing
     -- of an (*|) operator.

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -155,6 +155,13 @@ singleTests =
           updateConfig = \respectful opts -> opts {poRespectful = pure respectful},
           showTestCase = show,
           testCaseSuffix = suffix1
+        },
+      TestGroup
+        { label = "unicode-syntax",
+          testCases = allOptions,
+          updateConfig = \unicodePreference options -> options {poUnicode = pure unicodePreference},
+          showTestCase = show,
+          testCaseSuffix = suffix1
         }
     ]
 


### PR DESCRIPTION
Resolves #134 

Unicode looks delicious _(with an appropriate font)_, but there is no input method for it out of the box. Therefore, most people avoid it. Now we do not need an input method — it will input itself, solving the problem for good.