### PR TITLE
Only run macos job on latest stack.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
           - stack.yaml
         os:
           - ubuntu-latest
-          - macos-latest
+        include:
+          - stack_yaml: stack.yaml
+            os: macos-latest
 
     name: 'build_and_test: ${{ matrix.os }} - ${{ matrix.stack_yaml }}'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       matrix:
         stack_yaml:
-          # technically redundant, since this should be a symlink,
-          # but just to be extra sure
-          - stack.yaml
           - stack-ghc-8.10.yaml
           - stack-ghc-9.0.yaml
           - stack-ghc-9.2.yaml
+          # technically redundant, since this should be a symlink,
+          # but just to be extra sure
+          - stack.yaml
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
GitHub actions has limits on number of concurrent macos jobs, so we'll reduce our matrix for macos