### PR TITLE
CabalInfo: handle case where source dir is '.'

### DIFF
--- a/data/cabal-test/cabal-test.cabal
+++ b/data/cabal-test/cabal-test.cabal
@@ -1,0 +1,9 @@
+cabal-version:      2.4
+name:               cabal-test
+version:            0.0.1.0
+build-type:         Simple
+
+library
+    exposed-modules: Test
+    hs-source-dirs:  .
+    build-depends:   acme-missiles

--- a/src/Ormolu/Utils/Cabal.hs
+++ b/src/Ormolu/Utils/Cabal.hs
@@ -168,7 +168,7 @@ getExtensionAndDepsMap cabalFile GenericPackageDescription {..} =
 
     extractFromBuildInfo extraModules BuildInfo {..} = (,(exts, deps)) $ do
       m <- extraModules ++ (ModuleName.toFilePath <$> otherModules)
-      (takeDirectory cabalFile </>) <$> prependSrcDirs (dropExtensions m)
+      (takeDirectory cabalFile </>) . normalise <$> prependSrcDirs (dropExtensions m)
       where
         prependSrcDirs f
           | null hsSourceDirs = [f]

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -42,3 +42,6 @@ spec = do
     it "extracts correct dependencies from fourmolu.cabal (tests/Ormolu/PrinterSpec.hs)" $ do
       CabalInfo {..} <- parseCabalInfo "fourmolu.cabal" "tests/Ormolu/PrinterSpec.hs"
       ciDependencies `shouldBe` Set.fromList ["Diff", "QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "megaparsec", "fourmolu", "path", "path-io", "pretty", "temporary", "text"]
+    it "extracts info even when source dir is ." $ do
+      CabalInfo {..} <- parseCabalInfo "data/cabal-test/cabal-test.cabal" "data/cabal-test/Test.hs" 
+      ciDependencies `shouldBe` Set.fromList ["acme-missiles"]


### PR DESCRIPTION
If source dir in Cabal file is `.`, it can happen that `getExtensionAndDepsMap` returns a filename key like `path-to-cabalfile/./Some/Module.hs`, while searching for `path-to-cabalfile/Some/Module.hs`. In this case fourmolu fails to find the appropriate extensions and dependencies for that source file.

This PR fixes the problem by normalizing paths in `getExtensionAndDepsMap`, so that the lookup by source file name (which is also normalize) suceeds.

Also added a test case which reproduces the problem.