### PR TITLE
Release 0.8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fourmolu 0.8.2.0
+
+* Add `multi-line-compact` option to `haddock-style` that will output `{-|` for multiline haddocks instead of `{- |` ([#130](https://github.com/fourmolu/fourmolu/pull/130))
+* Add `function-arrows` configuration option to style arrow placement in type signatures ([#209](https://github.com/fourmolu/fourmolu/pull/209))
+
 ## Fourmolu 0.8.1.0
 
 * Add `emptyConfig` ([#221](https://github.com/fourmolu/fourmolu/pull/221))

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -105,6 +105,7 @@ To release a new version, do the following workflow:
     1. Curate option order
         * Re-order the "Available options" table in the `README` with the options sorted by popularity/importance (using your best judgement, without too much churn every release)
         * Ensure the options are in the same order in the `fourmolu.yaml` file and `README` examples
+        * Ensure the options are in the same order in `Ormolu.Config.Types`, `overFieldsM`, and `printerOptsMeta`
         * Ensure the `PrinterOptsSpec.hs` tests are also in the same order as the options
 
 1. Create PR as usual and merge into `main`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We share all bar one of Ormolu's goals:
 | `indent-wheres`          | `true`, `false` | `false` means save space by only half-indenting the `where` keyword |
 | `record-brace-space`     | `true`, `false` | `rec {x = 1}` vs `rec{x = 1}` |
 | `respectful`             | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
-| `haddock-style`          | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- |`, `{- |`, or `{-|` (single-line haddocks will always use `--` for now) |
+| `haddock-style`          | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- \|`, `{- \|`, or `{-\|` (single-line haddocks will always use `--` for now) |
 | `newlines-between-decls` | any integer     | number of newlines between top-level declarations |
 | `fixities`               | A list of strings | See the "Language extensions, dependencies, and fixities" section below |
 | `function-arrows`        | `trailing`, `leading`| How to format arrows in type signatures |

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ We share all bar one of Ormolu's goals:
 | Configuration option     | Valid options   | Description |
 |--------------------------|-----------------|-------------|
 | `indentation`            | any integer     | Number of spaces to use as indentation |
+| `function-arrows`        | `trailing`, `leading`| How to format arrows in type signatures |
 | `comma-style`            | `leading`, `trailing` | Where to put the comma in lists, tuples, etc. |
 | `import-export-style`    | `leading`, `trailing`, `diff-friendly` | How to format multiline import/export lists (`diff-friendly` lists have trailing commas but keep the open-parentheses on the same line as the `import` line) |
 | `indent-wheres`          | `true`, `false` | `false` means save space by only half-indenting the `where` keyword |
 | `record-brace-space`     | `true`, `false` | `rec {x = 1}` vs `rec{x = 1}` |
-| `respectful`             | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
-| `haddock-style`          | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- \|`, `{- \|`, or `{-\|` (single-line haddocks will always use `--` for now) |
 | `newlines-between-decls` | any integer     | number of newlines between top-level declarations |
+| `haddock-style`          | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- \|`, `{- \|`, or `{-\|` (single-line haddocks will always use `--` for now) |
+| `respectful`             | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
 | `fixities`               | A list of strings | See the "Language extensions, dependencies, and fixities" section below |
-| `function-arrows`        | `trailing`, `leading`| How to format arrows in type signatures |
 
 For examples of each of these options, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/).
 
@@ -64,30 +64,30 @@ A complete configuration file, corresponding to Fourmolu's default options, look
 
 ```yaml
 indentation: 4
+function-arrows: trailing
 comma-style: leading
 import-export-style: diff-friendly
 indent-wheres: false
 record-brace-space: false
-respectful: true
-haddock-style: multi-line
 newlines-between-decls: 1
+haddock-style: multi-line
+respectful: true
 fixities: []
-function-arrows: trailing
 ```
 
 The configuration that most closely matches Ormolu's styling is:
 
 ```yaml
 indentation: 2
+function-arrows: trailing
 comma-style: trailing
 import-export-style: trailing
 indent-wheres: true
 record-brace-space: true
-respectful: false
-haddock-style: single-line
 newlines-between-decls: 1
+haddock-style: single-line
+respectful: false
 fixities: []
-function-arrows: trailing
 ```
 
 Command-line options override options in a configuration file. Run `fourmolu --help` to see all options.

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ We share all bar one of Ormolu's goals:
 
 ### Available options
 
-| Configuration option | Valid options | Description |
-|----------------------|---------------|-------------|
-| `indentation`        | any integer   | Number of spaces to use as indentation |
-| `comma-style`        | `leading`, `trailing` | Where to put the comma in lists, tuples, etc. |
-| `import-export-style` | `leading`, `trailing`, `diff-friendly` | How to format multiline import/export lists (`diff-friendly` lists have trailing commas but keep the open-parentheses on the same line as the `import` line) |
-| `indent-wheres`      | `true`, `false` | `false` means save space by only half-indenting the `where` keyword |
-| `record-brace-space` | `true`, `false` | `rec {x = 1}` vs `rec{x = 1}` |
-| `respectful`         | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
-| `haddock-style`      | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- |`, `{- |`, or `{-|` (single-line haddocks will always use `--` for now) |
-| `newlines-between-decls` | any integer | number of newlines between top-level declarations |
-| `fixities`           | A list of strings for defining fixities; see the "Language extensions, dependencies, and fixities" section below |
-| `function-arrows`    | `trailing`, `leading`| How to format arrows in type signatures |
+| Configuration option     | Valid options   | Description |
+|--------------------------|-----------------|-------------|
+| `indentation`            | any integer     | Number of spaces to use as indentation |
+| `comma-style`            | `leading`, `trailing` | Where to put the comma in lists, tuples, etc. |
+| `import-export-style`    | `leading`, `trailing`, `diff-friendly` | How to format multiline import/export lists (`diff-friendly` lists have trailing commas but keep the open-parentheses on the same line as the `import` line) |
+| `indent-wheres`          | `true`, `false` | `false` means save space by only half-indenting the `where` keyword |
+| `record-brace-space`     | `true`, `false` | `rec {x = 1}` vs `rec{x = 1}` |
+| `respectful`             | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
+| `haddock-style`          | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- |`, `{- |`, or `{-|` (single-line haddocks will always use `--` for now) |
+| `newlines-between-decls` | any integer     | number of newlines between top-level declarations |
+| `fixities`               | A list of strings for defining fixities; see the "Language extensions, dependencies, and fixities" section below |
+| `function-arrows`        | `trailing`, `leading`| How to format arrows in type signatures |
 
 For examples of each of these options, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We share all bar one of Ormolu's goals:
 | `respectful`             | `true`, `false` | Whether to respect user-specified newlines, e.g. in import groupings |
 | `haddock-style`          | `single-line`, `multi-line`, `multi-line-compact` | Whether multiline haddocks should use `-- |`, `{- |`, or `{-|` (single-line haddocks will always use `--` for now) |
 | `newlines-between-decls` | any integer     | number of newlines between top-level declarations |
-| `fixities`               | A list of strings for defining fixities; see the "Language extensions, dependencies, and fixities" section below |
+| `fixities`               | A list of strings | See the "Language extensions, dependencies, and fixities" section below |
 | `function-arrows`        | `trailing`, `leading`| How to format arrows in type signatures |
 
 For examples of each of these options, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/).

--- a/changelog.d/function-arrows.md
+++ b/changelog.d/function-arrows.md
@@ -1,1 +1,0 @@
-Add `function-arrows` configuration option to style arrow placement in type signatures ([#209](https://github.com/fourmolu/fourmolu/pull/209))

--- a/changelog.d/multi-line-compact.md
+++ b/changelog.d/multi-line-compact.md
@@ -1,1 +1,0 @@
-Add `multi-line-compact` option to `haddock-style` that will output `{-|` for multiline haddocks instead of `{- |` ([#130](https://github.com/fourmolu/fourmolu/pull/130))

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               fourmolu
-version:            0.8.1.0
+version:            0.8.2.0
 license:            BSD-3-Clause
 license-file:       LICENSE.md
 maintainer:

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,11 +1,11 @@
 # Options should imitate Ormolu's style
 indentation: 2
+function-arrows: trailing
 comma-style: trailing
 import-export-style: trailing
 indent-wheres: true
 record-brace-space: true
-respectful: false
-haddock-style: single-line
 newlines-between-decls: 1
+haddock-style: single-line
+respectful: false
 fixities: []
-function-arrows: trailing

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -4,9 +4,9 @@
 module Ormolu.Config.Types
   ( PrinterOpts (..),
     CommaStyle (..),
+    FunctionArrowsStyle (..),
     HaddockPrintStyle (..),
     ImportExportStyle (..),
-    FunctionArrowsStyle (..),
   )
 where
 
@@ -16,6 +16,8 @@ import GHC.Generics (Generic)
 data PrinterOpts f = PrinterOpts
   { -- | Number of spaces to use for indentation
     poIndentation :: f Int,
+    -- | How to style arrows in type signatures
+    poFunctionArrows :: f FunctionArrowsStyle,
     -- | Whether to place commas at start or end of lines
     poCommaStyle :: f CommaStyle,
     -- | Styling of import/export lists
@@ -24,20 +26,23 @@ data PrinterOpts f = PrinterOpts
     poIndentWheres :: f Bool,
     -- | Leave space before opening record brace
     poRecordBraceSpace :: f Bool,
-    -- | Be less opinionated about spaces/newlines etc.
-    poRespectful :: f Bool,
-    -- | How to print doc comments
-    poHaddockStyle :: f HaddockPrintStyle,
     -- | Number of newlines between top-level decls
     poNewlinesBetweenDecls :: f Int,
-    -- | How to style arrows in type signatures
-    poFunctionArrows :: f FunctionArrowsStyle
+    -- | How to print doc comments
+    poHaddockStyle :: f HaddockPrintStyle,
+    -- | Be less opinionated about spaces/newlines etc.
+    poRespectful :: f Bool
   }
   deriving (Generic)
 
 data CommaStyle
   = Leading
   | Trailing
+  deriving (Eq, Show, Enum, Bounded)
+
+data FunctionArrowsStyle
+  = TrailingArrows
+  | LeadingArrows
   deriving (Eq, Show, Enum, Bounded)
 
 data HaddockPrintStyle
@@ -50,9 +55,4 @@ data ImportExportStyle
   = ImportExportLeading
   | ImportExportTrailing
   | ImportExportDiffFriendly
-  deriving (Eq, Show, Enum, Bounded)
-
-data FunctionArrowsStyle
-  = TrailingArrows
-  | LeadingArrows
   deriving (Eq, Show, Enum, Bounded)

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -66,6 +66,14 @@ spec =
             suffixWith [show indent, if indentWheres then "indent_wheres" else ""]
         },
       TestGroup
+        { label = "function-arrows",
+          testCases = allOptions,
+          updateConfig = \functionArrows opts ->
+            opts {poFunctionArrows = pure functionArrows},
+          showTestCase = show,
+          testCaseSuffix = suffix1
+        },
+      TestGroup
         { label = "comma-style",
           testCases = allOptions,
           updateConfig = \commaStyle opts -> opts {poCommaStyle = pure commaStyle},
@@ -88,20 +96,6 @@ spec =
           testCaseSuffix = suffix1
         },
       TestGroup
-        { label = "respectful",
-          testCases = allOptions,
-          updateConfig = \respectful opts -> opts {poRespectful = pure respectful},
-          showTestCase = show,
-          testCaseSuffix = suffix1
-        },
-      TestGroup
-        { label = "haddock-style",
-          testCases = allOptions,
-          updateConfig = \haddockStyle opts -> opts {poHaddockStyle = pure haddockStyle},
-          showTestCase = show,
-          testCaseSuffix = suffix1
-        },
-      TestGroup
         { label = "newlines-between-decls",
           testCases = (,) <$> [0, 1, 2] <*> allOptions,
           updateConfig = \(newlines, respectful) opts ->
@@ -115,10 +109,16 @@ spec =
             suffixWith [show newlines, if respectful then "respectful" else ""]
         },
       TestGroup
-        { label = "function-arrows",
+        { label = "haddock-style",
           testCases = allOptions,
-          updateConfig = \functionArrows opts ->
-            opts {poFunctionArrows = pure functionArrows},
+          updateConfig = \haddockStyle opts -> opts {poHaddockStyle = pure haddockStyle},
+          showTestCase = show,
+          testCaseSuffix = suffix1
+        },
+      TestGroup
+        { label = "respectful",
+          testCases = allOptions,
+          updateConfig = \respectful opts -> opts {poRespectful = pure respectful},
           showTestCase = show,
           testCaseSuffix = suffix1
         }


### PR DESCRIPTION
Ignore the branch name :)

Also includes doc changes. This is the first time we've included "curate the order of configuration options" in the release checklist, so this is a bit more churn than we should expect for future releases.

Rough reasoning for option order:

```yaml
# important options, probably the ones
# people will configure the most
indentation
function-arrows
comma-style
import-export-style

# less important options
indent-wheres
record-brace-space
newlines-between-decls
haddock-style

# respectful is a bit of a black box;
# maybe if it were better named, we
# could bump it up in importance
respectful

# fixities is last because people probably
# won't need to touch it too much. it's
# also a list, which looks nicer at the end
# of the file
fixities
```