### PR TITLE
Add cabal test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,8 @@ jobs:
           path: ~/.stack
           key: ${{ runner.os }}-stack_test-${{ matrix.stack_yaml }}-${{ hashFiles(matrix.stack_yaml, 'fourmolu.cabal') }}
 
-      - name: Build + Test
-        run: |
-          ARGS=(
-              # use development mode, to enable -Werror
-              --flag fourmolu:dev
-          )
-          stack build --test "${ARGS[@]}"
+      # use development mode, to enable -Werror
+      - run: stack test --flag fourmolu:dev
 
       - name: Check that Cabal file was generated
         run: git diff --exit-code '*.cabal'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
         value: ${{ jobs.build_prod.outputs.version }}
 
 jobs:
-  build_and_test:
+  stack_test:
     strategy:
       matrix:
         stack_yaml:
@@ -26,7 +26,7 @@ jobs:
           - stack_yaml: stack.yaml
             os: macos-latest
 
-    name: 'build_and_test: ${{ matrix.os }} - ${{ matrix.stack_yaml }}'
+    name: 'stack_test: ${{ matrix.os }} - ${{ matrix.stack_yaml }}'
     runs-on: ${{ matrix.os }}
     env:
       STACK_YAML: ${{ matrix.stack_yaml }}
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-build_and_test-${{ matrix.stack_yaml }}-${{ hashFiles(matrix.stack_yaml, 'fourmolu.cabal') }}
+          key: ${{ runner.os }}-stack_test-${{ matrix.stack_yaml }}-${{ hashFiles(matrix.stack_yaml, 'fourmolu.cabal') }}
 
       - name: Build + Test
         run: |
@@ -120,7 +120,7 @@ jobs:
               # install binary to ./bin/
               --copy-bins --local-bin-path ./bin/
 
-              # not using `dev` flag or testing; done in build_and_test job
+              # not using `dev` flag or testing; done in stack_test job
           )
           stack build "${ARGS[@]}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,9 @@ jobs:
           # technically redundant, since this should be a symlink,
           # but just to be extra sure
           - stack.yaml
-        os:
-          - ubuntu-latest
-        include:
-          - stack_yaml: stack.yaml
-            os: macos-latest
 
-    name: 'stack_test: ${{ matrix.os }} - ${{ matrix.stack_yaml }}'
-    runs-on: ${{ matrix.os }}
+    name: 'stack_test: ${{ matrix.stack_yaml }}'
+    runs-on: ubuntu-latest
     env:
       STACK_YAML: ${{ matrix.stack_yaml }}
 
@@ -71,6 +66,23 @@ jobs:
       - run: cabal update
       - run: cabal install --overwrite-policy=always alex happy
       - run: cabal test
+
+  os_test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    name: 'os_test: ${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v3
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-os_test-${{ hashFiles('stack.yaml', 'fourmolu.cabal') }}
+      - run: stack test --fast
 
   build_haddock:
     runs-on: ubuntu-latest
@@ -120,7 +132,7 @@ jobs:
               # install binary to ./bin/
               --copy-bins --local-bin-path ./bin/
 
-              # not using `dev` flag or testing; done in stack_test job
+              # not using `dev` flag or testing; done in `stack_test` + `os_test`
           )
           stack build "${ARGS[@]}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,29 @@ jobs:
       - name: Check that Cabal file was generated
         run: git diff --exit-code '*.cabal'
 
+  cabal_test:
+    strategy:
+      matrix:
+        ghc_version:
+          - '8.10'
+          - '9.0'
+          - '9.2'
+
+    name: 'cabal_test: ghc-${{ matrix.ghc_version }}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc_version }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cabal
+          key: ${{ runner.os }}-cabal-cache-${{ matrix.ghc_version }}-${{ hashFiles('fourmolu.cabal') }}
+      - run: cabal update
+      - run: cabal install --overwrite-policy=always alex happy
+      - run: cabal test
+
   build_haddock:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Trying to repro this failure: https://hackage.haskell.org/package/fourmolu-0.8.1.0/reports/2.
UPDATE: Seems like it's due to outdated packages on the Hackage server: https://github.com/digital-asset/ghc-lib/issues/407.

I'll still merge this in as a normal "build + test with cabal" test, which we should probably have anyway. I also took the opportunity to break up `build_and_test` into distinct `stack_test`, `cabal_test`, and `os_test` jobs.