### PR TITLE
Fixes for function arrows

### DIFF
--- a/changelog.d/function-arrows-fixes.md
+++ b/changelog.d/function-arrows-fixes.md
@@ -1,0 +1,1 @@
+Fix some edge cases with function arrows ([#247](https://github.com/fourmolu/fourmolu/pull/247))

--- a/data/examples/declaration/data/gadt/multiline-four-out.hs
+++ b/data/examples/declaration/data/gadt/multiline-four-out.hs
@@ -14,12 +14,8 @@ data Foo a where
         Foo 'Int
     -- | But 'Bar' is also not too bad.
     Bar ::
-        Int ->
-        Maybe Text ->
-        Foo 'Bool
+        Int -> Maybe Text -> Foo 'Bool
     -- | So is 'Baz'.
     Baz ::
-        forall a.
-        a ->
-        Foo 'String
+        forall a. a -> Foo 'String
     (:~>) :: Foo a -> Foo a -> Foo a

--- a/data/examples/declaration/data/gadt/multiline-out.hs
+++ b/data/examples/declaration/data/gadt/multiline-out.hs
@@ -14,12 +14,8 @@ data Foo a where
     Foo 'Int
   -- | But 'Bar' is also not too bad.
   Bar ::
-    Int ->
-    Maybe Text ->
-    Foo 'Bool
+    Int -> Maybe Text -> Foo 'Bool
   -- | So is 'Baz'.
   Baz ::
-    forall a.
-    a ->
-    Foo 'String
+    forall a. a -> Foo 'String
   (:~>) :: Foo a -> Foo a -> Foo a

--- a/data/examples/declaration/data/gadt/multiple-declaration-four-out.hs
+++ b/data/examples/declaration/data/gadt/multiple-declaration-four-out.hs
@@ -4,12 +4,10 @@ data GADT0 a where
 data GADT1 a where
     GADT11
         , GADT12 ::
-        Int ->
-        GADT1 a
+        Int -> GADT1 a
 
 data GADT2 a where
     GADT21
         , GADT21
         , GADT22 ::
-        Int ->
-        GADT2 a
+        Int -> GADT2 a

--- a/data/examples/declaration/data/gadt/multiple-declaration-out.hs
+++ b/data/examples/declaration/data/gadt/multiple-declaration-out.hs
@@ -4,12 +4,10 @@ data GADT0 a where
 data GADT1 a where
   GADT11,
     GADT12 ::
-    Int ->
-    GADT1 a
+    Int -> GADT1 a
 
 data GADT2 a where
   GADT21,
     GADT21,
     GADT22 ::
-    Int ->
-    GADT2 a
+    Int -> GADT2 a

--- a/data/fourmolu/function-arrows/input.hs
+++ b/data/fourmolu/function-arrows/input.hs
@@ -86,13 +86,6 @@ data Record = Record
   , recOther :: Bool
   }
 
-{-# SPECIALIZE foo :: Text -> Text #-}
-{-# SPECIALIZE
-      foo ::
-        Text ->
-        Text
-  #-}
-
 foo ::
   Int %1 ->
   Bool

--- a/data/fourmolu/function-arrows/input.hs
+++ b/data/fourmolu/function-arrows/input.hs
@@ -97,5 +97,6 @@ foo ::
   Int %1 ->
   Bool
 foo ::
+  forall x.
   Int %Many ->
   Bool

--- a/data/fourmolu/function-arrows/input.hs
+++ b/data/fourmolu/function-arrows/input.hs
@@ -83,3 +83,10 @@ data Record = Record
               Bool
   , recOther :: Bool
   }
+
+{-# SPECIALIZE foo :: Text -> Text #-}
+{-# SPECIALIZE
+      foo ::
+        Text ->
+        Text
+  #-}

--- a/data/fourmolu/function-arrows/input.hs
+++ b/data/fourmolu/function-arrows/input.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LinearTypes #-}
+
 module Main where
 
 -- | Something else.
@@ -90,3 +92,10 @@ data Record = Record
         Text ->
         Text
   #-}
+
+foo ::
+  Int %1 ->
+  Bool
+foo ::
+  Int %Many ->
+  Bool

--- a/data/fourmolu/function-arrows/input.hs
+++ b/data/fourmolu/function-arrows/input.hs
@@ -79,6 +79,39 @@ functionName ::
   (c -> d) ->
   (a, b, c, d)
 
+functionWithInterleavedCommentsTrailing ::
+  -- arg
+  Int ->
+  -- result
+  Bool
+
+functionWithInterleavedCommentsLeading
+  -- arg
+  :: Int
+  -- result
+  -> Bool
+
+multilineExprSig = do
+  bar
+    ( x ::
+        Int ->
+        Bool
+    )
+  bar
+    ( x ::
+        -- arg
+        Int ->
+        -- result
+        Bool
+    )
+  bar
+    ( x
+        -- arg
+        :: Int
+        -- result
+        -> Bool
+    )
+
 data Record = Record
   { recFun :: forall a. (C1, C2) => Int ->
               Int ->

--- a/data/fourmolu/function-arrows/output-LeadingArrows.hs
+++ b/data/fourmolu/function-arrows/output-LeadingArrows.hs
@@ -89,11 +89,6 @@ data Record = Record
     , recOther :: Bool
     }
 
-{-# SPECIALIZE foo :: Text -> Text #-}
-{-# SPECIALIZE foo
-    :: Text
-    -> Text
-    #-}
 foo
     :: Int
     %1 -> Bool

--- a/data/fourmolu/function-arrows/output-LeadingArrows.hs
+++ b/data/fourmolu/function-arrows/output-LeadingArrows.hs
@@ -87,3 +87,9 @@ data Record = Record
         -> Bool
     , recOther :: Bool
     }
+
+{-# SPECIALIZE foo :: Text -> Text #-}
+{-# SPECIALIZE foo
+    :: Text
+    -> Text
+    #-}

--- a/data/fourmolu/function-arrows/output-LeadingArrows.hs
+++ b/data/fourmolu/function-arrows/output-LeadingArrows.hs
@@ -98,5 +98,6 @@ foo
     :: Int
     %1 -> Bool
 foo
-    :: Int
+    :: forall x
+     . Int
     %Many -> Bool

--- a/data/fourmolu/function-arrows/output-LeadingArrows.hs
+++ b/data/fourmolu/function-arrows/output-LeadingArrows.hs
@@ -78,6 +78,37 @@ functionName
        )
     -> (c -> d)
     -> (a, b, c, d)
+functionWithInterleavedCommentsTrailing
+    -- arg
+    :: Int
+    -- result
+    -> Bool
+functionWithInterleavedCommentsLeading
+    -- arg
+    :: Int
+    -- result
+    -> Bool
+
+multilineExprSig = do
+    bar
+        ( x
+            :: Int
+            -> Bool
+        )
+    bar
+        ( x
+            -- arg
+            :: Int
+            -- result
+            -> Bool
+        )
+    bar
+        ( x
+            -- arg
+            :: Int
+            -- result
+            -> Bool
+        )
 
 data Record = Record
     { recFun

--- a/data/fourmolu/function-arrows/output-LeadingArrows.hs
+++ b/data/fourmolu/function-arrows/output-LeadingArrows.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LinearTypes #-}
 
 module Main where
 
@@ -93,3 +94,9 @@ data Record = Record
     :: Text
     -> Text
     #-}
+foo
+    :: Int
+    %1 -> Bool
+foo
+    :: Int
+    %Many -> Bool

--- a/data/fourmolu/function-arrows/output-TrailingArrows.hs
+++ b/data/fourmolu/function-arrows/output-TrailingArrows.hs
@@ -98,5 +98,6 @@ foo ::
     Int %1 ->
     Bool
 foo ::
+    forall x.
     Int %Many ->
     Bool

--- a/data/fourmolu/function-arrows/output-TrailingArrows.hs
+++ b/data/fourmolu/function-arrows/output-TrailingArrows.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LinearTypes #-}
 
 module Main where
 
@@ -93,3 +94,9 @@ data Record = Record
     Text ->
     Text
     #-}
+foo ::
+    Int %1 ->
+    Bool
+foo ::
+    Int %Many ->
+    Bool

--- a/data/fourmolu/function-arrows/output-TrailingArrows.hs
+++ b/data/fourmolu/function-arrows/output-TrailingArrows.hs
@@ -89,11 +89,6 @@ data Record = Record
     , recOther :: Bool
     }
 
-{-# SPECIALIZE foo :: Text -> Text #-}
-{-# SPECIALIZE foo ::
-    Text ->
-    Text
-    #-}
 foo ::
     Int %1 ->
     Bool

--- a/data/fourmolu/function-arrows/output-TrailingArrows.hs
+++ b/data/fourmolu/function-arrows/output-TrailingArrows.hs
@@ -87,3 +87,9 @@ data Record = Record
         Bool
     , recOther :: Bool
     }
+
+{-# SPECIALIZE foo :: Text -> Text #-}
+{-# SPECIALIZE foo ::
+    Text ->
+    Text
+    #-}

--- a/data/fourmolu/function-arrows/output-TrailingArrows.hs
+++ b/data/fourmolu/function-arrows/output-TrailingArrows.hs
@@ -78,6 +78,37 @@ functionName ::
     ) ->
     (c -> d) ->
     (a, b, c, d)
+functionWithInterleavedCommentsTrailing ::
+    -- arg
+    Int ->
+    -- result
+    Bool
+functionWithInterleavedCommentsLeading ::
+    -- arg
+    Int ->
+    -- result
+    Bool
+
+multilineExprSig = do
+    bar
+        ( x ::
+            Int ->
+            Bool
+        )
+    bar
+        ( x ::
+            -- arg
+            Int ->
+            -- result
+            Bool
+        )
+    bar
+        ( x ::
+            -- arg
+            Int ->
+            -- result
+            Bool
+        )
 
 data Record = Record
     { recFun ::

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -76,9 +76,8 @@ module Ormolu.Printer.Combinators
     Placement (..),
     placeHanging,
 
-    -- ** Helpers for leading/trailing arrows
-    leadingArrowType,
-    trailingArrowType,
+    -- ** Helpers for function-arrows configuration
+    startTypeAnnotation,
   )
 where
 
@@ -374,20 +373,10 @@ placeHanging placement m =
 ----------------------------------------------------------------------------
 -- Arrow style
 
--- | Output @space >> txt "::"@ when we are printing with trailing arrows
-trailingArrowType :: R ()
-trailingArrowType =
+-- | Add the "::" marker that starts a type annotation, running the given
+-- action either before or after the marker, depending on poFunctionArrows.
+startTypeAnnotation :: R () -> R ()
+startTypeAnnotation m =
   getPrinterOpt poFunctionArrows >>= \case
-    TrailingArrows -> do
-      space
-      txt "::"
-    LeadingArrows -> pure ()
-
--- | Output @txt "::" >> space@ when we are printing with leading arrows
-leadingArrowType :: R ()
-leadingArrowType =
-  getPrinterOpt poFunctionArrows >>= \case
-    LeadingArrows -> do
-      txt "::"
-      space
-    TrailingArrows -> pure ()
+    TrailingArrows -> space >> txt "::" >> m
+    LeadingArrows -> m >> txt "::" >> space

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -29,7 +29,6 @@ module Ormolu.Printer.Combinators
     askSourceType,
     askFixityOverrides,
     askFixityMap,
-    inciByExact,
     located,
     located',
     switchLayout,

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -74,9 +74,6 @@ module Ormolu.Printer.Combinators
     -- ** Placement
     Placement (..),
     placeHanging,
-
-    -- ** Helpers for function-arrows configuration
-    startTypeAnnotation,
   )
 where
 
@@ -85,7 +82,6 @@ import Data.List (intersperse)
 import Data.Text (Text)
 import GHC.Types.SrcLoc
 import Ormolu.Config
-import Ormolu.Config.Types (FunctionArrowsStyle (..))
 import Ormolu.Printer.Comments
 import Ormolu.Printer.Internal
 import Ormolu.Utils (HasSrcSpan (..))
@@ -368,14 +364,3 @@ placeHanging placement m =
     Normal -> do
       breakpoint
       inci m
-
-----------------------------------------------------------------------------
--- Arrow style
-
--- | Add the "::" marker that starts a type annotation, running the given
--- action either before or after the marker, depending on poFunctionArrows.
-startTypeAnnotation :: R () -> R ()
-startTypeAnnotation m =
-  getPrinterOpt poFunctionArrows >>= \case
-    TrailingArrows -> space >> txt "::" >> m
-    LeadingArrows -> m >> txt "::" >> space

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -26,7 +26,6 @@ module Ormolu.Printer.Internal
     inciBy,
     inciByFrac,
     inciHalf,
-    inciByExact,
     sitcc,
     sitccIfTrailing,
     Layout (..),
@@ -449,15 +448,6 @@ inci = inciByFrac 1
 -- than 'indentStep'.
 inciHalf :: R () -> R ()
 inciHalf = inciByFrac 2
-
--- | Like 'inci', but indents by exactly the given number of spaces.
-inciByExact :: Int -> R () -> R ()
-inciByExact spaces (R m) = R (local modRC m)
-  where
-    modRC rc =
-      rc
-        { rcIndent = rcIndent rc + spaces
-        }
 
 -- | Set indentation level for the inner computation equal to current
 -- column. This makes sure that the entire inner block is uniformly

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -58,9 +58,6 @@ module Ormolu.Printer.Internal
 
     -- * Extensions
     isExtensionEnabled,
-    PrevTypeCtx (..),
-    getPrevTypeCtx,
-    setPrevTypeCtx,
   )
 where
 
@@ -138,9 +135,7 @@ data SC = SC
     -- | Whether to output a space before the next output
     scRequestedDelimiter :: !RequestedDelimiter,
     -- | An auxiliary marker for keeping track of last output element
-    scSpanMark :: !(Maybe SpanMark),
-    -- | What (if any) precedes the current type on the same line
-    scPrevTypeCtx :: PrevTypeCtx
+    scSpanMark :: !(Maybe SpanMark)
   }
 
 -- | Make sure next output is delimited by one of the following.
@@ -217,8 +212,7 @@ runR (R m) sstream cstream printerOpts sourceType extensions fixityOverrides fix
           scCommentStream = cstream,
           scPendingComments = [],
           scRequestedDelimiter = VeryBeginning,
-          scSpanMark = Nothing,
-          scPrevTypeCtx = TypeCtxStart
+          scSpanMark = Nothing
         }
 
 ----------------------------------------------------------------------------
@@ -644,22 +638,3 @@ canUseBraces = R (asks rcCanUseBraces)
 
 isExtensionEnabled :: Extension -> R Bool
 isExtensionEnabled ext = R . asks $ EnumSet.member ext . rcExtensions
-
-----------------------------------------------------------------------------
--- Previous type context
-
--- | What (if anything) precedes the current type on the same line
--- Only used for the `function-arrows` setting
-data PrevTypeCtx
-  = TypeCtxStart
-  | TypeCtxForall
-  | TypeCtxContext
-  | TypeCtxArgument
-  deriving (Eq, Show)
-
-getPrevTypeCtx :: R PrevTypeCtx
-getPrevTypeCtx = R (gets scPrevTypeCtx)
-
-setPrevTypeCtx :: PrevTypeCtx -> R ()
-setPrevTypeCtx prevTypeCtx =
-  R $ modify (\sc -> sc {scPrevTypeCtx = prevTypeCtx})

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -126,12 +126,6 @@ p_conDecl singleConstRec = \case
             commaDel
             sep commaDel p_rdrName cs
       inci $ do
-        startTypeAnnotation $ do
-          let interArgBreak =
-                if hasDocStrings (unLoc con_res_ty)
-                  then newline
-                  else breakpoint
-          interArgBreak
         let conTy = case con_g_args of
               PrefixConGADT xs ->
                 let go (HsScaled a b) t = addCLocAA t b (HsFunTy EpAnnNotUsed a b t)
@@ -151,7 +145,7 @@ p_conDecl singleConstRec = \case
             quantifiedTy =
               addCLocAA con_bndrs qualTy $
                 hsOuterTyVarBndrsToHsType (unLoc con_bndrs) qualTy
-        located quantifiedTy p_hsType
+        startTypeAnnotationDecl quantifiedTy id p_hsType
   ConDeclH98 {..} -> do
     mapM_ (p_hsDocString Pipe True) con_doc
     let conDeclWithContextSpn =

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -151,7 +151,7 @@ p_conDecl singleConstRec = \case
             quantifiedTy =
               addCLocAA con_bndrs qualTy $
                 hsOuterTyVarBndrsToHsType (unLoc con_bndrs) qualTy
-        p_hsType (unLoc quantifiedTy)
+        located quantifiedTy p_hsType
   ConDeclH98 {..} -> do
     mapM_ (p_hsDocString Pipe True) con_doc
     let conDeclWithContextSpn =

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -126,13 +126,12 @@ p_conDecl singleConstRec = \case
             commaDel
             sep commaDel p_rdrName cs
       inci $ do
-        trailingArrowType
-        let interArgBreak =
-              if hasDocStrings (unLoc con_res_ty)
-                then newline
-                else breakpoint
-        interArgBreak
-        leadingArrowType
+        startTypeAnnotation $ do
+          let interArgBreak =
+                if hasDocStrings (unLoc con_res_ty)
+                  then newline
+                  else breakpoint
+          interArgBreak
         let conTy = case con_g_args of
               PrefixConGADT xs ->
                 let go (HsScaled a b) t = addCLocAA t b (HsFunTy EpAnnNotUsed a b t)

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -60,11 +60,10 @@ p_typeAscription ::
   LHsSigType GhcPs ->
   R ()
 p_typeAscription sigType = inci $ do
-  trailingArrowType
-  if hasDocStrings (unLoc . sig_body . unLoc $ sigType)
-    then newline
-    else breakpoint
-  leadingArrowType
+  startTypeAnnotation $
+    if hasDocStrings (unLoc . sig_body . unLoc $ sigType)
+      then newline
+      else breakpoint
   located sigType p_hsSigType
 
 p_patSynSig ::
@@ -138,9 +137,7 @@ p_specSig name ts InlinePragma {..} = pragmaBraces $ do
   space
   p_rdrName name
   inci $ do
-    trailingArrowType
-    breakpoint
-    leadingArrowType
+    startTypeAnnotation breakpoint
     sep commaDel (located' p_hsSigType) ts
 
 p_inlineSpec :: InlineSpec -> R ()
@@ -226,7 +223,5 @@ p_standaloneKindSig (StandaloneKindSig _ name sigTy) = do
   inci $ do
     space
     p_rdrName name
-    trailingArrowType
-    breakpoint
-    leadingArrowType
+    startTypeAnnotation breakpoint
     located sigTy p_hsSigType

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -59,12 +59,8 @@ p_typeSig indentTail (n : ns) sigType = do
 p_typeAscription ::
   LHsSigType GhcPs ->
   R ()
-p_typeAscription sigType = inci $ do
-  startTypeAnnotation $
-    if hasDocStrings (unLoc . sig_body . unLoc $ sigType)
-      then newline
-      else breakpoint
-  located sigType p_hsSigType
+p_typeAscription lsigType =
+  inci $ startTypeAnnotationDecl lsigType (unLoc . sig_body) p_hsSigType
 
 p_patSynSig ::
   [LocatedN RdrName] ->
@@ -224,5 +220,4 @@ p_standaloneKindSig (StandaloneKindSig _ name sigTy) = do
   inci $ do
     space
     p_rdrName name
-    startTypeAnnotation breakpoint
-    located sigTy p_hsSigType
+    startTypeAnnotation sigTy p_hsSigType

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -136,9 +136,10 @@ p_specSig name ts InlinePragma {..} = pragmaBraces $ do
   p_activation inl_act
   space
   p_rdrName name
-  inci $ do
-    startTypeAnnotation breakpoint
-    sep commaDel (located' p_hsSigType) ts
+  space
+  txt "::"
+  breakpoint
+  inci $ sep commaDel (located' p_hsSigType) ts
 
 p_inlineSpec :: InlineSpec -> R ()
 p_inlineSpec = \case

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -137,10 +137,10 @@ p_specSig name ts InlinePragma {..} = pragmaBraces $ do
   p_activation inl_act
   space
   p_rdrName name
-  trailingArrowType
   inci $ do
-    leadingArrowType
+    trailingArrowType
     breakpoint
+    leadingArrowType
     sep commaDel (located' p_hsSigType) ts
 
 p_inlineSpec :: InlineSpec -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -208,9 +208,9 @@ p_completeSig cs' mty =
     pragma "COMPLETE" . inci $ do
       sep commaDel p_rdrName cs
       forM_ mty $ \ty -> do
-        trailingArrowType
+        space
+        txt "::"
         breakpoint
-        leadingArrowType
         inci (p_rdrName ty)
 
 p_sccSig :: LocatedN RdrName -> Maybe (Located StringLiteral) -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -63,8 +63,7 @@ p_familyResultSigL ::
 p_familyResultSigL (L _ a) = case a of
   NoSig NoExtField -> Nothing
   KindSig NoExtField k -> Just $ do
-    startTypeAnnotation breakpoint
-    located k p_hsType
+    startTypeAnnotation k p_hsType
   TyVarSig NoExtField bndr -> Just $ do
     equals
     breakpoint

--- a/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/TypeFamily.hs
@@ -63,9 +63,7 @@ p_familyResultSigL ::
 p_familyResultSigL (L _ a) = case a of
   NoSig NoExtField -> Nothing
   KindSig NoExtField k -> Just $ do
-    trailingArrowType
-    breakpoint
-    leadingArrowType
+    startTypeAnnotation breakpoint
     located k p_hsType
   TyVarSig NoExtField bndr -> Just $ do
     equals

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -820,8 +820,7 @@ p_hsExpr' s = \case
     p_fieldLabels (NE.toList proj_flds)
   ExprWithTySig _ x HsWC {hswc_body} -> sitcc $ do
     located x p_hsExpr
-    startTypeAnnotation breakpoint
-    inci $ located hswc_body p_hsSigType
+    inci $ startTypeAnnotation hswc_body p_hsSigType
   ArithSeq _ _ x ->
     case x of
       From from -> brackets s $ do

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -820,9 +820,7 @@ p_hsExpr' s = \case
     p_fieldLabels (NE.toList proj_flds)
   ExprWithTySig _ x HsWC {hswc_body} -> sitcc $ do
     located x p_hsExpr
-    trailingArrowType
-    breakpoint
-    leadingArrowType
+    startTypeAnnotation breakpoint
     inci $ located hswc_body p_hsSigType
   ArithSeq _ _ x ->
     case x of

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -73,12 +73,8 @@ p_hsType' multilineArgs docStyle = \case
       HsForAllInvis _ bndrs -> p_forallBndrs' ForAllInvis p_hsTyVarBndr bndrs
       HsForAllVis _ bndrs -> p_forallBndrs' ForAllVis p_hsTyVarBndr bndrs
     getPrinterOpt poFunctionArrows >>= \case
-      LeadingArrows | multilineArgs -> pure ()
-      _ -> p_after False
-    interArgBreak
-    getPrinterOpt poFunctionArrows >>= \case
-      LeadingArrows | multilineArgs -> p_after True
-      _ -> pure ()
+      LeadingArrows | multilineArgs -> interArgBreak >> p_after True
+      _ -> p_after False >> interArgBreak
     p_hsTypeR (unLoc t)
   HsQualTy _ qs' t -> do
     getPrinterOpt poFunctionArrows >>= \case
@@ -87,15 +83,13 @@ p_hsType' multilineArgs docStyle = \case
         bool id (inciByExact 3) (after == TypeCtxForall) $ for_ qs' $ \qs -> do
           located qs p_hsContext
           interArgBreak
+        txt "=>" >> space
       TrailingArrows -> do
         for_ qs' $ \qs -> do
           located qs p_hsContext
           space
           txt "=>"
           interArgBreak
-    getPrinterOpt poFunctionArrows >>= \case
-      TrailingArrows -> pure ()
-      LeadingArrows -> txt "=>" >> space
     case unLoc t of
       HsQualTy {} -> p_hsTypeR (unLoc t)
       HsFunTy {} -> p_hsTypeR (unLoc t)

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -76,6 +76,9 @@ p_hsType' multilineArgs docStyle = \case
       LeadingArrows | multilineArgs -> pure ()
       _ -> p_after False >> setPrevTypeCtx TypeCtxStart
     interArgBreak
+    getPrinterOpt poFunctionArrows >>= \case
+      TrailingArrows -> pure ()
+      LeadingArrows -> p_after multilineArgs
     p_hsTypeR (unLoc t)
   HsQualTy _ qs' t -> do
     getPrinterOpt poFunctionArrows >>= \case
@@ -91,6 +94,9 @@ p_hsType' multilineArgs docStyle = \case
           txt "=>"
           interArgBreak
     setPrevTypeCtx TypeCtxContext
+    getPrinterOpt poFunctionArrows >>= \case
+      TrailingArrows -> pure ()
+      LeadingArrows -> p_after multilineArgs
     case unLoc t of
       HsQualTy {} -> p_hsTypeR (unLoc t)
       HsFunTy {} -> p_hsTypeR (unLoc t)
@@ -134,6 +140,9 @@ p_hsType' multilineArgs docStyle = \case
             HsLinearArrow _ _ -> txt "%1 ->"
             HsExplicitMult _ _ mult -> do
               txt "%"
+              getPrinterOpt poFunctionArrows >>= \case
+                TrailingArrows -> pure ()
+                LeadingArrows -> p_after multilineArgs
               p_hsTypeR (unLoc mult)
               space
               txt "->"
@@ -150,6 +159,9 @@ p_hsType' multilineArgs docStyle = \case
         p_arrow
         interArgBreak
     setPrevTypeCtx TypeCtxStart
+    getPrinterOpt poFunctionArrows >>= \case
+      TrailingArrows -> pure ()
+      LeadingArrows -> p_after multilineArgs
     case y' of
       HsFunTy {} -> do
         layout <- getLayout
@@ -241,11 +253,7 @@ p_hsType' multilineArgs docStyle = \case
       if multilineArgs
         then newline
         else breakpoint
-    p_hsTypeR m = do
-      getPrinterOpt poFunctionArrows >>= \case
-        TrailingArrows -> pure ()
-        LeadingArrows -> p_after multilineArgs
-      p_hsType' multilineArgs docStyle m
+    p_hsTypeR m = p_hsType' multilineArgs docStyle m
 
 -- | Return 'True' if at least one argument in 'HsType' has a doc string
 -- attached to it.

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -76,18 +76,11 @@ p_hsType' multilineArgs docStyle = \case
       _ -> p_after False >> interArgBreak
     p_hsTypeR (unLoc t)
   HsQualTy _ qs' t -> do
-    getPrinterOpt poFunctionArrows >>= \case
-      LeadingArrows -> do
-        for_ qs' $ \qs -> do
-          located qs p_hsContext
-          interArgBreak
-        txt "=>" >> space
-      TrailingArrows -> do
-        for_ qs' $ \qs -> do
-          located qs p_hsContext
-          space
-          txt "=>"
-          interArgBreak
+    for_ qs' $ \qs -> do
+      located qs p_hsContext
+      getPrinterOpt poFunctionArrows >>= \case
+        LeadingArrows -> interArgBreak >> txt "=>" >> space
+        TrailingArrows -> space >> txt "=>" >> interArgBreak
     case unLoc t of
       HsQualTy {} -> p_hsTypeR (unLoc t)
       HsFunTy {} -> p_hsTypeR (unLoc t)
@@ -134,17 +127,10 @@ p_hsType' multilineArgs docStyle = \case
               p_hsTypeR (unLoc mult)
               space
               txt "->"
+    located x p_hsType
     getPrinterOpt poFunctionArrows >>= \case
-      LeadingArrows -> do
-        located x p_hsType
-        interArgBreak
-        p_arrow
-        space
-      TrailingArrows -> do
-        located x p_hsType
-        space
-        p_arrow
-        interArgBreak
+      LeadingArrows -> interArgBreak >> p_arrow >> space
+      TrailingArrows -> space >> p_arrow >> interArgBreak
     case y' of
       HsFunTy {} -> do
         layout <- getLayout

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -50,7 +50,6 @@ p_after multilineArgs =
     TypeCtxContext -> txt "=>" >> space
     TypeCtxArgument -> txt "->" >> space
 
--- | Like 'p_hsType' but indent properly following a forall
 p_hsType :: HsType GhcPs -> R ()
 p_hsType t = do
   s <-

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -140,9 +140,6 @@ p_hsType' multilineArgs docStyle = \case
             HsLinearArrow _ _ -> txt "%1 ->"
             HsExplicitMult _ _ mult -> do
               txt "%"
-              getPrinterOpt poFunctionArrows >>= \case
-                TrailingArrows -> pure ()
-                LeadingArrows -> p_after multilineArgs
               p_hsTypeR (unLoc mult)
               space
               txt "->"

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -178,16 +178,12 @@ p_hsType' multilineArgs docStyle = \case
     parens N $ sitcc $ located t p_hsType
   HsIParamTy _ n t -> sitcc $ do
     located n atom
-    trailingArrowType
-    breakpoint
-    leadingArrowType
+    startTypeAnnotation breakpoint
     inci (located t p_hsType)
   HsStarTy _ _ -> txt "*"
   HsKindSig _ t k -> sitcc $ do
     located t p_hsType
-    trailingArrowType
-    breakpoint
-    leadingArrowType
+    startTypeAnnotation breakpoint
     inci (located k p_hsType)
   HsSpliceTy _ splice -> p_hsSplice splice
   HsDocTy _ t str ->
@@ -285,9 +281,7 @@ p_hsTyVarBndr = \case
     (if isInferred flag then braces N else id) $ p_rdrName x
   KindedTyVar _ flag l k -> (if isInferred flag then braces else parens) N . sitcc $ do
     located l atom
-    trailingArrowType
-    breakpoint
-    leadingArrowType
+    startTypeAnnotation breakpoint
     inci (located k p_hsType)
 
 data ForAllVisibility = ForAllInvis | ForAllVis

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -23,7 +23,6 @@ module Ormolu.Printer.Meat.Type
 where
 
 import Control.Monad
-import Data.Bool (bool)
 import Data.Foldable (for_)
 import GHC.Hs
 import GHC.Types.Basic hiding (isPromoted)
@@ -79,8 +78,7 @@ p_hsType' multilineArgs docStyle = \case
   HsQualTy _ qs' t -> do
     getPrinterOpt poFunctionArrows >>= \case
       LeadingArrows -> do
-        after <- getPrevTypeCtx
-        bool id (inciByExact 3) (after == TypeCtxForall) $ for_ qs' $ \qs -> do
+        for_ qs' $ \qs -> do
           located qs p_hsContext
           interArgBreak
         txt "=>" >> space
@@ -138,8 +136,7 @@ p_hsType' multilineArgs docStyle = \case
               txt "->"
     getPrinterOpt poFunctionArrows >>= \case
       LeadingArrows -> do
-        after <- getPrevTypeCtx
-        bool id (inciByExact 3) (after == TypeCtxForall) (located x p_hsType)
+        located x p_hsType
         interArgBreak
         p_arrow
         space

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -130,25 +130,28 @@ p_hsType' multilineArgs docStyle = \case
       txt "@"
       located kd p_hsType
   HsFunTy _ arrow x y@(L _ y') -> do
+    let p_arrow =
+          case arrow of
+            HsUnrestrictedArrow _ -> txt "->"
+            HsLinearArrow _ _ -> txt "%1 ->"
+            HsExplicitMult _ _ mult -> do
+              txt "%"
+              p_hsTypeR (unLoc mult)
+              space
+              txt "->"
     getPrinterOpt poFunctionArrows >>= \case
       LeadingArrows -> do
         after <- getPrevTypeCtx
         bool id (inciByExact 3) (after == TypeCtxForall) (located x p_hsType)
         interArgBreak
+        p_arrow
+        space
       TrailingArrows -> do
         located x p_hsType
         space
-        case arrow of
-          HsUnrestrictedArrow _ -> txt "->"
-          HsLinearArrow _ _ -> txt "%1 ->"
-          HsExplicitMult _ _ mult -> do
-            txt "%"
-            setPrevTypeCtx TypeCtxContext
-            p_hsTypeR (unLoc mult)
-            space
-            txt "->"
+        p_arrow
         interArgBreak
-    setPrevTypeCtx TypeCtxArgument
+    setPrevTypeCtx TypeCtxStart
     case y' of
       HsFunTy {} -> do
         layout <- getLayout

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -74,11 +74,11 @@ p_hsType' multilineArgs docStyle = \case
       HsForAllVis _ bndrs -> p_forallBndrs' ForAllVis p_hsTyVarBndr bndrs
     getPrinterOpt poFunctionArrows >>= \case
       LeadingArrows | multilineArgs -> pure ()
-      _ -> p_after False >> setPrevTypeCtx TypeCtxStart
+      _ -> p_after False
     interArgBreak
     getPrinterOpt poFunctionArrows >>= \case
-      TrailingArrows -> pure ()
-      LeadingArrows -> p_after multilineArgs
+      LeadingArrows | multilineArgs -> p_after True
+      _ -> pure ()
     p_hsTypeR (unLoc t)
   HsQualTy _ qs' t -> do
     getPrinterOpt poFunctionArrows >>= \case
@@ -93,10 +93,9 @@ p_hsType' multilineArgs docStyle = \case
           space
           txt "=>"
           interArgBreak
-    setPrevTypeCtx TypeCtxContext
     getPrinterOpt poFunctionArrows >>= \case
       TrailingArrows -> pure ()
-      LeadingArrows -> p_after multilineArgs
+      LeadingArrows -> txt "=>" >> space
     case unLoc t of
       HsQualTy {} -> p_hsTypeR (unLoc t)
       HsFunTy {} -> p_hsTypeR (unLoc t)
@@ -155,10 +154,6 @@ p_hsType' multilineArgs docStyle = \case
         space
         p_arrow
         interArgBreak
-    setPrevTypeCtx TypeCtxStart
-    getPrinterOpt poFunctionArrows >>= \case
-      TrailingArrows -> pure ()
-      LeadingArrows -> p_after multilineArgs
     case y' of
       HsFunTy {} -> do
         layout <- getLayout

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -45,8 +45,7 @@ p_after :: Bool -> R ()
 p_after multilineArgs =
   getPrevTypeCtx >>= \case
     TypeCtxStart -> pure ()
-    TypeCtxForall | multilineArgs -> txt " ." >> space
-    TypeCtxForall -> txt "." >> space
+    TypeCtxForall -> when multilineArgs (txt " ") >> txt "." >> space
     TypeCtxContext -> txt "=>" >> space
     TypeCtxArgument -> txt "->" >> space
 


### PR DESCRIPTION
Found some edge cases for function arrows, and was able to simplify the code without the `PrevTypeCtx` machinery.

Some of the changes I made seem to still pass tests (e.g. moving things in/out of a `located` block). If we find a regression or issue later, we can fix it later with an added test