### PR TITLE
Add version of `git ls-files` command which avoids length limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Or find all files in a project with `git ls-files`:
 
 ```console
 $ fourmolu --mode inplace $(git ls-files '*.hs')
+# Or to avoid hitting command line length limits:
+$ git ls-files -z '*.hs' | xargs -0 fourmolu --mode inplace
 ```
 
 To check if files are are already formatted (useful on CI):

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $ fourmolu -i src
 
 Or find all files in a project with `git ls-files`:
 
-```console
+```bash
 $ fourmolu --mode inplace $(git ls-files '*.hs')
 # Or to avoid hitting command line length limits:
 $ git ls-files -z '*.hs' | xargs -0 fourmolu --mode inplace


### PR DESCRIPTION
Changed my mind as soon as I hit merge on https://github.com/fourmolu/fourmolu/pull/263.

Credit to @clintonmead.