### PR TITLE
Merge ormolu 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         stack_yaml:
-          - stack-ghc-9.0.yaml
           - stack-ghc-9.2.yaml
           - stack-ghc-9.4.yaml
+          - stack-ghc-9.6.yaml
           # technically redundant, since this should be a symlink,
           # but just to be extra sure
           - stack.yaml
@@ -53,9 +53,9 @@ jobs:
     strategy:
       matrix:
         ghc_version:
-          - '9.0'
           - '9.2'
           - '9.4'
+          - '9.6'
 
     name: 'cabal_test: ghc-${{ matrix.ghc_version }}'
     runs-on: ubuntu-latest

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Main (main) where
 
@@ -14,12 +11,12 @@ import Control.Exception (throwIO)
 import Control.Monad
 import Data.Bool (bool)
 import Data.List (intercalate, isSuffixOf, sort)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
-import qualified Data.Set as Set
-import qualified Data.Text.IO as TIO
+import Data.Set qualified as Set
+import Data.Text.IO qualified as TIO
 import Data.Version (showVersion)
-import qualified Data.Yaml as Yaml
+import Data.Yaml qualified as Yaml
 import Language.Haskell.TH.Env (envQ)
 import Options.Applicative
 import Ormolu
@@ -34,7 +31,7 @@ import Ormolu.Utils.IO
 import Paths_fourmolu (version)
 import System.Directory
 import System.Exit (ExitCode (..), exitWith)
-import qualified System.FilePath as FP
+import System.FilePath qualified as FP
 import System.IO (hPutStrLn, stderr)
 
 -- | Entry point of the program.

--- a/changelog.d/ormolu-0.6.0.1.md
+++ b/changelog.d/ormolu-0.6.0.1.md
@@ -1,0 +1,29 @@
+## Ormolu 0.6.0.1
+
+* Fix false positives in AST diffing related to `UnicodeSyntax`. [PR
+  1009](https://github.com/tweag/ormolu/pull/1009).
+
+## Ormolu 0.6.0.0
+
+* Haddocks attached to arguments of a data constructor are now formatted in
+  the pipe style (rather than the caret style), consistent with everything
+  else. As a consequence, now Ormolu's output will be deemed invalid by the
+  Haddock shipped with GHC <9.0. [Issue
+  844](https://github.com/tweag/ormolu/issues/844) and [issue
+  828](https://github.com/tweag/ormolu/issues/828).
+
+* Insert space before char literals in ticked promoted constructs when
+  necessary. [Issue 1000](https://github.com/tweag/ormolu/issues/1000).
+
+* Switched to `ghc-lib-parser-9.6`:
+  * Extended `OverloadedLabels`: `#Foo`, `#3`, `#"Hello there"`.
+
+    Also, it is now disabled by default, as it causes e.g. `a#b` to be parsed
+    differently.
+  * New extension: `TypeData`, enabled by default.
+  * Parse errors now include error codes, cf. https://errors.haskell.org.
+
+* Updated to `Cabal-syntax-3.10`.
+
+* Now whenever Ormolu fails to parse a `.cabal` file it also explains why.
+  [PR 999](https://github.com/tweag/ormolu/pull/999).

--- a/data/examples/declaration/data/gadt/unicode-four-out.hs
+++ b/data/examples/declaration/data/gadt/unicode-four-out.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+data Foo :: Type -> Type where
+    Foo :: a -> Foo a

--- a/data/examples/declaration/data/gadt/unicode-out.hs
+++ b/data/examples/declaration/data/gadt/unicode-out.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+data Foo :: Type -> Type where
+  Foo :: a -> Foo a

--- a/data/examples/declaration/data/gadt/unicode.hs
+++ b/data/examples/declaration/data/gadt/unicode.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE UnicodeSyntax #-}
+
+data Foo ∷ Type → Type where
+  Foo ∷ a → Foo a

--- a/data/examples/declaration/data/type-data-four-out.hs
+++ b/data/examples/declaration/data/type-data-four-out.hs
@@ -1,0 +1,8 @@
+type data Universe = Character | Number | Boolean
+
+type data Maybe a
+    = Just a
+    | Nothing
+
+type data P :: Type -> Type -> Type where
+    MkP :: (a ~ Natural, b ~~ Char) => P a b

--- a/data/examples/declaration/data/type-data-out.hs
+++ b/data/examples/declaration/data/type-data-out.hs
@@ -1,0 +1,8 @@
+type data Universe = Character | Number | Boolean
+
+type data Maybe a
+  = Just a
+  | Nothing
+
+type data P :: Type -> Type -> Type where
+  MkP :: (a ~ Natural, b ~~ Char) => P a b

--- a/data/examples/declaration/data/type-data.hs
+++ b/data/examples/declaration/data/type-data.hs
@@ -1,0 +1,7 @@
+type data Universe = Character | Number | Boolean
+
+type data Maybe a = Just a
+                  | Nothing
+
+type data P :: Type -> Type -> Type where
+  MkP :: (a ~ Natural, b ~~ Char) => P a b

--- a/data/examples/declaration/data/unnamed-field-comment-0-four-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-0-four-out.hs
@@ -1,7 +1,7 @@
 data Foo
     = -- | Bar
       Bar
+        -- | Field 1
         Field1
-        -- ^ Field 1
+        -- | Field 2
         Field2
-        -- ^ Field 2

--- a/data/examples/declaration/data/unnamed-field-comment-0-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-0-out.hs
@@ -1,7 +1,7 @@
 data Foo
   = -- | Bar
     Bar
+      -- | Field 1
       Field1
-      -- ^ Field 1
+      -- | Field 2
       Field2
-      -- ^ Field 2

--- a/data/examples/declaration/data/unnamed-field-comment-1-four-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-1-four-out.hs
@@ -1,5 +1,5 @@
 data X
     = B
+        -- | y
         !Int
-        -- ^ y
         C

--- a/data/examples/declaration/data/unnamed-field-comment-1-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-1-out.hs
@@ -1,5 +1,5 @@
 data X
   = B
+      -- | y
       !Int
-      -- ^ y
       C

--- a/data/examples/declaration/data/unnamed-field-comment-2-four-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-2-four-out.hs
@@ -1,0 +1,11 @@
+-- | Describes what sort of dictionary to generate for type class instances
+data Evidence
+    = -- | An existing named instance
+      NamedInstance (Qualified Ident)
+    | -- | Computed instances
+      WarnInstance
+        -- | Warn type class with a user-defined warning message
+        SourceType
+    | -- | The IsSymbol type class for a given Symbol literal
+      IsSymbolInstance PSString
+    deriving (Show, Eq)

--- a/data/examples/declaration/data/unnamed-field-comment-2-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-2-out.hs
@@ -1,0 +1,11 @@
+-- | Describes what sort of dictionary to generate for type class instances
+data Evidence
+  = -- | An existing named instance
+    NamedInstance (Qualified Ident)
+  | -- | Computed instances
+    WarnInstance
+      -- | Warn type class with a user-defined warning message
+      SourceType
+  | -- | The IsSymbol type class for a given Symbol literal
+    IsSymbolInstance PSString
+  deriving (Show, Eq)

--- a/data/examples/declaration/data/unnamed-field-comment-2.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-2.hs
@@ -1,0 +1,9 @@
+-- | Describes what sort of dictionary to generate for type class instances
+data Evidence
+  -- | An existing named instance
+  = NamedInstance (Qualified Ident)
+
+  -- | Computed instances
+  | WarnInstance SourceType -- ^ Warn type class with a user-defined warning message
+  | IsSymbolInstance PSString -- ^ The IsSymbol type class for a given Symbol literal
+  deriving (Show, Eq)

--- a/data/examples/declaration/data/unnamed-field-comment-3-four-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-3-four-out.hs
@@ -1,0 +1,5 @@
+data A
+    = A
+        -- | a number
+        Int
+        Bool

--- a/data/examples/declaration/data/unnamed-field-comment-3-out.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-3-out.hs
@@ -1,0 +1,5 @@
+data A
+  = A
+      -- | a number
+      Int
+      Bool

--- a/data/examples/declaration/data/unnamed-field-comment-3.hs
+++ b/data/examples/declaration/data/unnamed-field-comment-3.hs
@@ -1,0 +1,1 @@
+data A = A {- | a number -} Int Bool

--- a/data/examples/declaration/type-families/closed-type-family/promotion-four-out.hs
+++ b/data/examples/declaration/type-families/closed-type-family/promotion-four-out.hs
@@ -1,0 +1,2 @@
+type family Foo a where
+    Foo '( 'x', a) = a

--- a/data/examples/declaration/type-families/closed-type-family/promotion-out.hs
+++ b/data/examples/declaration/type-families/closed-type-family/promotion-out.hs
@@ -1,0 +1,2 @@
+type family Foo a where
+  Foo '( 'x', a) = a

--- a/data/examples/declaration/type-families/closed-type-family/promotion.hs
+++ b/data/examples/declaration/type-families/closed-type-family/promotion.hs
@@ -1,0 +1,2 @@
+type family Foo a where
+  Foo '( 'x', a) = a

--- a/data/examples/declaration/type/promotion-1-four-out.hs
+++ b/data/examples/declaration/type/promotion-1-four-out.hs
@@ -9,3 +9,5 @@ type E = TypeError ('Text "Some text")
 type G = '[ '( 'Just, 'Bool)]
 
 type X = () '`PromotedInfix` ()
+
+type A = '[ 'a']

--- a/data/examples/declaration/type/promotion-1-out.hs
+++ b/data/examples/declaration/type/promotion-1-out.hs
@@ -15,3 +15,5 @@ type E = TypeError ('Text "Some text")
 type G = '[ '( 'Just, 'Bool)]
 
 type X = () '`PromotedInfix` ()
+
+type A = '[ 'a']

--- a/data/examples/declaration/type/promotion-1.hs
+++ b/data/examples/declaration/type/promotion-1.hs
@@ -9,3 +9,5 @@ type E = TypeError ('Text "Some text")
 type G = '[ '( 'Just, 'Bool) ]
 
 type X = () '`PromotedInfix` ()
+
+type A = '[ 'a' ]

--- a/data/examples/declaration/value/function/overloaded-labels-four-out.hs
+++ b/data/examples/declaration/value/function/overloaded-labels-four-out.hs
@@ -2,3 +2,35 @@
 
 foo = #field
 bar = (#this) (#that)
+baz = #Foo #"Hello world!" #"\"" #3 #"\n"
+
+-- from https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.6.1-alpha3/testsuite/tests/overloadedrecflds/should_run/T11671_run.hs
+-- unnecessary once https://github.com/tweag/ormolu/issues/821 lands
+main =
+    traverse_
+        putStrLn
+        [ #a
+        , #number17
+        , #do
+        , #type
+        , #Foo
+        , #3
+        , #"199.4"
+        , #17a23b
+        , #f'a'
+        , #'a'
+        , #'
+        , #''notTHSplice
+        , #"..."
+        , #привет
+        , #こんにちは
+        , #"3"
+        , #":"
+        , #"Foo"
+        , #"The quick brown fox"
+        , #"\""
+        , (++) #hello #world
+        , (++) #"hello" #"world"
+        , #"hello" # 1 -- equivalent to `(fromLabel @"hello") # 1`
+        , f "hello" #2 -- equivalent to `f ("hello"# :: Addr#) 2`
+        ]

--- a/data/examples/declaration/value/function/overloaded-labels-out.hs
+++ b/data/examples/declaration/value/function/overloaded-labels-out.hs
@@ -3,3 +3,36 @@
 foo = #field
 
 bar = (#this) (#that)
+
+baz = #Foo #"Hello world!" #"\"" #3 #"\n"
+
+-- from https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.6.1-alpha3/testsuite/tests/overloadedrecflds/should_run/T11671_run.hs
+-- unnecessary once https://github.com/tweag/ormolu/issues/821 lands
+main =
+  traverse_
+    putStrLn
+    [ #a,
+      #number17,
+      #do,
+      #type,
+      #Foo,
+      #3,
+      #"199.4",
+      #17a23b,
+      #f'a',
+      #'a',
+      #',
+      #''notTHSplice,
+      #"...",
+      #привет,
+      #こんにちは,
+      #"3",
+      #":",
+      #"Foo",
+      #"The quick brown fox",
+      #"\"",
+      (++) #hello #world,
+      (++) #"hello" #"world",
+      #"hello" # 1, -- equivalent to `(fromLabel @"hello") # 1`
+      f "hello" #2 -- equivalent to `f ("hello"# :: Addr#) 2`
+    ]

--- a/data/examples/declaration/value/function/overloaded-labels.hs
+++ b/data/examples/declaration/value/function/overloaded-labels.hs
@@ -2,3 +2,33 @@
 
 foo = #field
 bar = (#this ) ( #that)
+baz = #Foo #"Hello world!" #"\"" #3 #"\n"
+
+-- from https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.6.1-alpha3/testsuite/tests/overloadedrecflds/should_run/T11671_run.hs
+-- unnecessary once https://github.com/tweag/ormolu/issues/821 lands
+main = traverse_ putStrLn
+  [ #a
+  , #number17
+  , #do
+  , #type
+  , #Foo
+  , #3
+  , #"199.4"
+  , #17a23b
+  , #f'a'
+  , #'a'
+  , #'
+  , #''notTHSplice
+  , #"..."
+  , #привет
+  , #こんにちは
+  , #"3"
+  , #":"
+  , #"Foo"
+  , #"The quick brown fox"
+  , #"\""
+  , (++) #hello#world
+  , (++) #"hello"#"world"
+  , #"hello"# 1 -- equivalent to `(fromLabel @"hello") # 1`
+  , f "hello"#2 -- equivalent to `f ("hello"# :: Addr#) 2`
+  ]

--- a/expected-failures/esqueleto.txt
+++ b/expected-failures/esqueleto.txt
@@ -1,3 +1,3 @@
 src/Database/Esqueleto/Internal/Internal.hs:410:1
   The GHC parser (in Haddock mode) failed:
-  lexical error in string/character literal at character 's'
+  [GHC-21231] lexical error in string/character literal at character 's'

--- a/expected-failures/hlint.txt
+++ b/expected-failures/hlint.txt
@@ -1,31 +1,32 @@
 src/Extension.hs
-@@ -17,6 +17,7 @@
+@@ -17,7 +17,8 @@
            UnboxedTuples,
            UnboxedSums, -- breaks (#) lens operator
            QuasiQuotes, -- breaks [x| ...], making whitespace free list comps break
 -          {- DoRec , -} RecursiveDo, -- breaks rec
 +          {- DoRec , -}
 +          RecursiveDo, -- breaks rec
-           LexicalNegation -- changes '-', see https://github.com/ndmitchell/hlint/issues/1230
-         ]
+           LexicalNegation, -- changes '-', see https://github.com/ndmitchell/hlint/issues/1230
+           -- These next two change syntax significantly and must be opt-in.
+           OverloadedRecordDot,
 
   Formatting is not idempotent.
   Please, consider reporting the bug.
 src/Hint/Bracket.hs
-@@ -263,8 +263,11 @@
-                 let y = noLoc $ HsApp noExtField a1 (noLoc (HsPar noExtField a2)),
-                 let r = Replace Expr (toSS e) [("a", toSS a1), ("b", toSS a2)] "a (b)"
+@@ -259,8 +259,11 @@
+                 let y = noLocA $ HsApp EpAnnNotUsed a1 (noLocA (HsPar EpAnnNotUsed a2)),
+                 let r = Replace Expr (toSSA e) [("a", toSSA a1), ("b", toSSA a2)] "a (b)"
              ]
--         ++ [ (suggest "Redundant bracket" x y [r]) {ideaSpan -- Special case of (v1 . v2) <$> v3
--                                                     = locPar}
-+         ++ [ (suggest "Redundant bracket" x y [r])
+-         ++ [ (suggest "Redundant bracket" (reLoc x) (reLoc y) [r]) {ideaSpan -- Special case of (v1 . v2) <$> v3
+-                                                                     = locA locPar}
++         ++ [ (suggest "Redundant bracket" (reLoc x) (reLoc y) [r])
 +                { ideaSpan -- Special case of (v1 . v2) <$> v3
 +                  =
-+                    locPar
++                    locA locPar
 +                }
                | L _ (OpApp _ (L locPar (HsPar _ o1@(L locNoPar (OpApp _ _ (isDot -> True) _)))) o2 v3) <- [x],
                  varToStr o2 == "<$>",
-                 let y = noLoc (OpApp noExtField o1 o2 v3) :: LHsExpr GhcPs,
+                 let y = noLocA (OpApp EpAnnNotUsed o1 o2 v3) :: LHsExpr GhcPs,
 
   Formatting is not idempotent.
   Please, consider reporting the bug.

--- a/expected-failures/leksah.txt
+++ b/expected-failures/leksah.txt
@@ -1,6 +1,6 @@
 src/IDE/Find.hs:615:36-46
   The GHC parser (in Haddock mode) failed:
-  Bang pattern in expression context: !matchIndex
+  [GHC-95644] Bang pattern in expression context: !matchIndex
 Did you mean to add a space after the '!'?
 src/IDE/Pane/Modules.hs
 @@ -1183,9 +1183,9 @@

--- a/expected-failures/lens.txt
+++ b/expected-failures/lens.txt
@@ -1,3 +1,3 @@
-tests/properties.hs:121:26-28
+tests/properties.hs:117:26-28
   The GHC parser (in Haddock mode) failed:
-  parse error on input `KVS'
+  [GHC-58481] parse error on input `KVS'

--- a/expected-failures/pandoc.txt
+++ b/expected-failures/pandoc.txt
@@ -13,7 +13,7 @@ src/Text/Pandoc/Readers/Org/Inlines.hs
   Formatting is not idempotent.
   Please, consider reporting the bug.
 src/Text/Pandoc/Readers/RST.hs
-@@ -1119,7 +1119,7 @@
+@@ -1124,7 +1124,7 @@
               -- if no ":class:" field is given, the default is the role name
               classFieldClasses = maybe [role] T.words (lookup "class" fields)
 -             -- nub in case role name & language class are the same

--- a/expected-failures/postgrest.txt
+++ b/expected-failures/postgrest.txt
@@ -1,42 +1,21 @@
-src/PostgREST/Request/DbRequestBuilder.hs
-@@ -202,12 +202,11 @@
-                     -- /projects?select=clients(*)
-                     origin == tableName relTable
-                       && target == tableName relForeignTable -- projects
--                      || -- clients
-+                      || ( origin == tableName relTable -- clients
-                       -- /projects?select=projects_client_id_fkey(*)
--                      ( origin == tableName relTable
--                          && matchConstraint (Just target) relCardinality -- projects
--                          -- projects_client_id_fkey
--                      )
-+                             && matchConstraint (Just target) relCardinality -- projects
-+                             -- projects_client_id_fkey
-+                         )
-                       ||
-                       -- /projects?select=client_id(*)
-                       ( origin == tableName relTable
-@@ -216,16 +215,14 @@
-                       )
-                   )
-                && ( isNothing hint
--                      || -- hint is optional
-+                      || matchConstraint hint relCardinality -- hint is optional
-                       -- /projects?select=clients!projects_client_id_fkey(*)
--                      matchConstraint hint relCardinality
--                      || -- projects_client_id_fkey
-+                      || matchFKSingleCol hint relColumns -- projects_client_id_fkey
-                       -- /projects?select=clients!client_id(*) or /projects?select=clients!id(*)
--                      matchFKSingleCol hint relColumns
-                       || matchFKSingleCol hint relForeignColumns -- client_id
--                      || -- id
-+                      || matchJunction hint relCardinality -- id
-                       -- /users?select=tasks!users_tasks(*) many-to-many between users and tasks
--                      matchJunction hint relCardinality -- users_tasks
-+                      -- users_tasks
-                   )
+src/PostgREST/Plan.hs
+@@ -273,13 +273,12 @@
+                        && (
+                             -- /projects?select=clients!projects_client_id_fkey(*)
+                             matchConstraint hnt relCardinality
+-                              || -- projects_client_id_fkey
++                              || matchFKSingleCol hnt relCardinality -- projects_client_id_fkey
+                               -- /projects?select=clients!client_id(*) or /projects?select=clients!id(*)
+-                              matchFKSingleCol hnt relCardinality
+                               || matchFKRefSingleCol hnt relCardinality -- client_id
+-                              || -- id
++                              || matchJunction hnt relCardinality -- id
+                               -- /users?select=tasks!users_tasks(*) many-to-many between users and tasks
+-                              matchJunction hnt relCardinality -- users_tasks
++                              -- users_tasks
+                           )
           )
-          allRels
+          $ fromMaybe mempty
 
   Formatting is not idempotent.
   Please, consider reporting the bug.

--- a/expected-failures/purescript.txt
+++ b/expected-failures/purescript.txt
@@ -1,5 +1,5 @@
 src/Language/PureScript/CoreFn/CSE.hs
-@@ -218,11 +218,12 @@
+@@ -227,11 +227,12 @@
     at d . non mempty . at e %%<~ \case
       Nothing -> freshIdent (nameHint e) <&> \ident -> ((True, ident), Just ident)
       Just ident -> pure ((False, ident), Just ident)
@@ -17,7 +17,7 @@ src/Language/PureScript/CoreFn/CSE.hs
   Formatting is not idempotent.
   Please, consider reporting the bug.
 src/Language/PureScript/CoreFn/Laziness.hs
-@@ -527,12 +527,12 @@
+@@ -525,12 +525,12 @@
                           makeForceCall ann ident'
                     q -> Var ann q
              in (ident, rewriteExpr <$> item)

--- a/extract-hackage-info/extract-hackage-info.cabal
+++ b/extract-hackage-info/extract-hackage-info.cabal
@@ -7,10 +7,10 @@ author:        Thomas Bagrel <thomas.bagrel@tweag.io>
 executable extract-hackage-info
     main-is:          Main.hs
     hs-source-dirs:   src
-    default-language: Haskell2010
+    default-language: GHC2021
     ghc-options:      -O2 -Wall -rtsopts -Wunused-packages
     build-depends:
-        Cabal-syntax >=3.8 && <3.9,
+        Cabal-syntax >=3.10 && <3.11,
         base >=4.12 && <5.0,
         binary >=0.8 && <0.9,
         bytestring >=0.10 && <0.12,

--- a/extract-hackage-info/src/Main.hs
+++ b/extract-hackage-info/src/Main.hs
@@ -1,35 +1,29 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Main (main) where
 
 import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
-import qualified Data.Binary as Binary
-import qualified Data.Binary.Put as Binary
-import qualified Data.ByteString as ByteString
-import qualified Data.ByteString.Lazy as BL
+import Data.Binary qualified as Binary
+import Data.Binary.Put qualified as Binary
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Lazy qualified as BL
 import Data.List
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe
 import Data.Semigroup (sconcat)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeLatin1)
-import qualified Data.Text.IO as TIO
+import Data.Text.IO qualified as TIO
 import Data.Void (Void)
 import Distribution.Types.PackageName (PackageName, mkPackageName, unPackageName)
 import Formatting
@@ -42,8 +36,8 @@ import System.FilePath (makeRelative, splitPath, (</>))
 import System.IO (stderr, stdout)
 import Text.HTML.TagSoup (Tag (TagText), parseTags)
 import Text.HTML.TagSoup.Match (tagCloseLit, tagOpenLit)
-import qualified Text.Megaparsec as MP
-import qualified Text.Megaparsec.Char as MP
+import Text.Megaparsec qualified as MP
+import Text.Megaparsec.Char qualified as MP
 
 defaultOutputPath :: FilePath
 defaultOutputPath = "extract-hackage-info/hackage-info.bin"

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -7,7 +7,7 @@ maintainer:
     Matt Parsons <parsonsmatt@gmail.com>
     George Thomas <georgefsthomas@gmail.com>
     Brandon Chinn <brandonchinn178@gmail.com>
-tested-with:        ghc ==9.0.2 ghc ==9.2.5
+tested-with:        ghc ==9.2.7 ghc ==9.4.4 ghc ==9.6.1
 homepage:           https://github.com/fourmolu/fourmolu
 bug-reports:        https://github.com/fourmolu/fourmolu/issues
 synopsis:           A formatter for Haskell source code
@@ -91,6 +91,7 @@ library
         Ormolu.Processing.Cpp
         Ormolu.Processing.Preprocess
         Ormolu.Terminal
+        Ormolu.Terminal.QualifiedDo
         Ormolu.Utils
         Ormolu.Utils.Cabal
         Ormolu.Utils.Fixity
@@ -100,9 +101,9 @@ library
 
     hs-source-dirs:   src
     other-modules:    GHC.DynFlags
-    default-language: Haskell2010
+    default-language: GHC2021
     build-depends:
-        Cabal-syntax >=3.8 && <3.9,
+        Cabal-syntax >=3.10 && <3.11,
         Diff >=0.4 && <1.0,
         MemoTrie >=0.6 && <0.7,
         ansi-terminal >=0.10 && <1.0,
@@ -111,11 +112,11 @@ library
         binary >=0.8 && <0.9,
         bytestring >=0.2 && <0.12,
         containers >=0.5 && <0.7,
+        deepseq >=1.4 && <1.5,
         directory ^>=1.3,
-        dlist >=0.8 && <2.0,
         file-embed >=0.0.15 && <0.1,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
+        ghc-lib-parser >=9.6 && <9.7,
         megaparsec >=9.0,
         mtl >=2.0 && <3.0,
         syb >=0.7 && <0.8,
@@ -127,9 +128,8 @@ library
 
     if flag(dev)
         ghc-options:
-            -Wall -Werror -Wcompat -Wincomplete-record-updates
-            -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
-            -Wno-missing-home-modules -Wunused-packages
+            -Wall -Werror -Wredundant-constraints -Wpartial-fields
+            -Wunused-packages
 
     else
         ghc-options: -O2 -Wall
@@ -142,13 +142,13 @@ executable fourmolu
     hs-source-dirs:   app
     other-modules:    Paths_fourmolu
     autogen-modules:  Paths_fourmolu
-    default-language: Haskell2010
+    default-language: GHC2021
     build-depends:
         base >=4.12 && <5.0,
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
+        ghc-lib-parser >=9.6 && <9.7,
         th-env >=0.1.1 && <0.2,
         optparse-applicative >=0.14 && <0.18,
         text >=2.0 && <3.0,
@@ -159,10 +159,8 @@ executable fourmolu
 
     if flag(dev)
         ghc-options:
-            -Wall -Werror -Wcompat -Wincomplete-record-updates
-            -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
-            -optP-Wno-nonportable-include-path -Wunused-packages
-            -Wwarn=unused-packages
+            -Wall -Werror -Wredundant-constraints -Wpartial-fields
+            -Wunused-packages -Wwarn=unused-packages
 
     else
         ghc-options: -O2 -Wall -rtsopts
@@ -193,15 +191,15 @@ test-suite tests
         Ormolu.Parser.PragmaSpec
         Ormolu.PrinterSpec
 
-    default-language:   Haskell2010
+    default-language:   GHC2021
     build-depends:
-        Cabal-syntax >=3.8 && <3.9,
+        Cabal-syntax >=3.10 && <3.11,
         QuickCheck >=2.14,
         base >=4.14 && <5.0,
         containers >=0.5 && <0.7,
         directory ^>=1.3,
         filepath >=1.2 && <1.5,
-        ghc-lib-parser >=9.4 && <9.5,
+        ghc-lib-parser >=9.6 && <9.7,
         hspec >=2.0 && <3.0,
         hspec-megaparsec >=2.2,
         path >=0.6 && <0.10,
@@ -219,7 +217,9 @@ test-suite tests
         fourmolu
 
     if flag(dev)
-        ghc-options: -Wall -Werror -Wunused-packages
+        ghc-options:
+            -Wall -Werror -Wredundant-constraints -Wpartial-fields
+            -Wunused-packages
 
     else
         ghc-options: -O2 -Wall

--- a/ormolu-live/app/Main.hs
+++ b/ormolu-live/app/Main.hs
@@ -2,19 +2,20 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Main where
 
+import Control.DeepSeq (force)
 import Control.Exception qualified as E
 import Data.Aeson qualified as A
 import Data.ByteString.Lazy qualified as BL
 import Data.ByteString.Unsafe qualified as BU
-import Data.Knob qualified as Knob
+import Data.Functor (void)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.Encoding qualified as T
-import Foreign
+import Foreign hiding (void)
 import Foreign.C.Types
 import GHC.Driver.Ppr (showSDocUnsafe)
 import GHC.Generics (Generic)
@@ -22,12 +23,11 @@ import GHC.Hs.Dump qualified as Dump
 import Ormolu
 import Ormolu.Config qualified as O
 import Ormolu.Exception qualified as O
+import Ormolu.Fixity qualified as O
 import Ormolu.Fixity.Internal qualified as O
 import Ormolu.Parser qualified as O
 import Ormolu.Parser.Result as O
 import Ormolu.Terminal qualified as O
-import System.Environment (setEnv)
-import System.IO (IOMode (..))
 
 main :: IO ()
 main = mempty
@@ -52,12 +52,11 @@ formatRaw inputPtr inputLen outputPtrPtr = do
     copyBytes outputPtr buf len
     pure len
 
-foreign export ccall initFixityDB :: Ptr CChar -> Int -> IO ()
+foreign export ccall evaluateFixityInfo :: IO ()
 
-initFixityDB :: Ptr CChar -> Int -> IO ()
-initFixityDB ptr len = do
-  let IntPtr ptr' = ptrToIntPtr ptr
-  setEnv "ORMOLU_HACKAGE_INFO" $ show (ptr', len)
+evaluateFixityInfo :: IO ()
+evaluateFixityInfo =
+  void . E.evaluate $ force (O.packageToOps, O.packageToPopularity)
 
 -- actual logic
 
@@ -82,11 +81,7 @@ data Output = Output
 format :: Input -> IO Output
 format Input {..} = do
   output <-
-    (Right <$> ormolu cfg "<input>" inputStr) `E.catch` \ex -> do
-      knob <- Knob.newKnob mempty
-      Knob.withFileHandle knob "err" WriteMode $
-        O.runTerm (O.printOrmoluException ex) Never
-      Left . T.decodeUtf8 <$> Knob.getContents knob
+    (Right <$> ormolu cfg "<input>" inputStr) `E.catch` (pure . Left . O.runTermPure . O.printOrmoluException)
   inputAST <- if showAST then prettyAST cfg inputStr else pure T.empty
   outputAST <- case output of
     Right src' | showAST -> prettyAST cfg src'

--- a/ormolu-live/build-wasm.sh
+++ b/ormolu-live/build-wasm.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 set -e
+WDIR="$(mktemp -d)"
+trap 'rm -rf -- "$WDIR"' EXIT
+
 wasm32-wasi-cabal build exe:ormolu-live
 wasm32-wasi-cabal list-bin exe:ormolu-live
-ORMOLU_WASM="$(wasm32-wasi-cabal list-bin exe:ormolu-live).wasm"
+ORMOLU_WASM="$(wasm32-wasi-cabal list-bin exe:ormolu-live)"
+wizer \
+    --allow-wasi --wasm-bulk-memory true \
+    "$ORMOLU_WASM" -o "$WDIR/ormolu-init.wasm" \
+    --mapdir /::../extract-hackage-info
 if [ $# -eq 0 ]; then
-    cp "$ORMOLU_WASM" src/ormolu.wasm
+    ORMOLU_WASM_OPT="$WDIR/ormolu-init.wasm"
 else
-    wasm-opt "$@" "$ORMOLU_WASM" -o src/ormolu.wasm
+    ORMOLU_WASM_OPT="$WDIR/ormolu-opt.wasm"
+    wasm-opt "$@" "$WDIR/ormolu-init.wasm" -o "$ORMOLU_WASM_OPT"
 fi
+cp "$ORMOLU_WASM_OPT" src/ormolu.wasm

--- a/ormolu-live/cabal.project
+++ b/ormolu-live/cabal.project
@@ -1,21 +1,20 @@
 packages: . ..
 
 index-state:
-  , hackage.haskell.org 2023-01-13T16:50:23Z
-  , head.hackage 2022-12-25T15:05:28Z
-
-allow-newer: base, ghc-prim, transformers, unix
+  , hackage.haskell.org 2023-03-16T09:32:28Z
+  , head.hackage 2023-02-16T05:32:02Z
 
 package ormolu
+  -- The WASM backend does not support TH.
   flags: -internal-bundle-fixities
 
--- Reasons for the fork:
---  - Disable threaded runtime: https://github.com/digital-asset/ghc-lib/issues/184#issuecomment-1372466968
---    Will be unnecessary starting with the next ghc-lib-parser release.
---  - Remove build-tool-depends. Cabal does not support cross-toolchains.
---  - Fix compile error due to GHC 9.6 change: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.6#type-changing-record-updates-involving-type-families
+package ghc-lib-parser
+  -- The WASM backend does not support the threaded RTS.
+  flags: -threaded-rts
+
+-- Remove build-tool-depends as Cabal does not support cross-toolchains.
 source-repository-package
   type: git
   location: https://github.com/amesgen/stuff
-  tag: 7745cda8368298589fd70f34463c24dcaa6145ea
-  subdir: ghc-lib-parser-9.4.4.20221225
+  tag: 6cd8d7efd9704d3a3384eb91b4fe9d9912b52739
+  subdir: ghc-lib-parser-9.6.1.20230312-wasm

--- a/ormolu-live/cbits/init.c
+++ b/ormolu-live/cbits/init.c
@@ -1,0 +1,14 @@
+#include "Main_stub.h"
+#include <Rts.h>
+
+__attribute__((export_name("wizer.initialize"))) void __wizer_initialize(void) {
+  char *args[] = {
+      "ormolu-live.wasm", "+RTS", "--nonmoving-gc", "-H64m", "-RTS", NULL};
+  int argc = sizeof(args) / sizeof(args[0]) - 1;
+  char **argv = args;
+  hs_init_with_rtsopts(&argc, &argv);
+  evaluateFixityInfo();
+  hs_perform_gc();
+  hs_perform_gc();
+  rts_clearMemory();
+}

--- a/ormolu-live/ormolu-live.cabal
+++ b/ormolu-live/ormolu-live.cabal
@@ -6,11 +6,12 @@ author:        Alexander Esgen <alexander.esgen@tweag.io>
 
 executable ormolu-live
     main-is:          Main.hs
+    c-sources:        cbits/init.c
     hs-source-dirs:   app
     default-language: GHC2021
     ghc-options:
         -Wall -Wunused-packages -no-hs-main -optl-mexec-model=reactor
-        "-optl-Wl,--export=hs_init,--export=malloc,--export=mallocPtr,--export=free,--export=formatRaw,--export=initFixityDB"
+        "-optl-Wl,--export=malloc,--export=mallocPtr,--export=free,--export=formatRaw"
 
     build-depends:
         base,
@@ -19,4 +20,4 @@ executable ormolu-live
         text,
         aeson,
         ghc-lib-parser,
-        knob
+        deepseq

--- a/ormolu-live/package-lock.json
+++ b/ormolu-live/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ormolu-live",
       "version": "0.0.0",
       "dependencies": {
-        "@bjorn3/browser_wasi_shim": "^0.2.1",
+        "@bjorn3/browser_wasi_shim": "^0.2.3",
         "ace-builds": "^1.14.0",
         "bulma": "^0.9.4",
         "clipboard": "^2.0.11"
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@bjorn3/browser_wasi_shim": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.1.tgz",
-      "integrity": "sha512-QBI2VPoCksV+bN47v1edbFC0td1nXvEhK3i1oTrByKOnLG39RoxZR2KmLByR/6S+8ivAf2E4pWhqRRZsBWItyQ=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.3.tgz",
+      "integrity": "sha512-TZSyN5YX58ijMbcLm1NuPdAxXms5EGKNCP0j9WmRP6jxzxJO6PYr7d1TtyQaE+sbkN5CWhP3UsYjYzQpgrRwKg=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -6775,9 +6775,9 @@
       }
     },
     "@bjorn3/browser_wasi_shim": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.1.tgz",
-      "integrity": "sha512-QBI2VPoCksV+bN47v1edbFC0td1nXvEhK3i1oTrByKOnLG39RoxZR2KmLByR/6S+8ivAf2E4pWhqRRZsBWItyQ=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.3.tgz",
+      "integrity": "sha512-TZSyN5YX58ijMbcLm1NuPdAxXms5EGKNCP0j9WmRP6jxzxJO6PYr7d1TtyQaE+sbkN5CWhP3UsYjYzQpgrRwKg=="
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/ormolu-live/package.json
+++ b/ormolu-live/package.json
@@ -9,7 +9,7 @@
     "purs-backend-es": "^1.3.1"
   },
   "dependencies": {
-    "@bjorn3/browser_wasi_shim": "^0.2.1",
+    "@bjorn3/browser_wasi_shim": "^0.2.3",
     "ace-builds": "^1.14.0",
     "bulma": "^0.9.4",
     "clipboard": "^2.0.11"

--- a/ormolu-live/src/hackage-info.bin
+++ b/ormolu-live/src/hackage-info.bin
@@ -1,1 +1,0 @@
-../../extract-hackage-info/hackage-info.bin

--- a/src/GHC/DynFlags.hs
+++ b/src/GHC/DynFlags.hs
@@ -49,8 +49,5 @@ fakeSettings =
           }
     }
 
-fakeLlvmConfig :: LlvmConfig
-fakeLlvmConfig = LlvmConfig [] []
-
 baseDynFlags :: DynFlags
-baseDynFlags = defaultDynFlags fakeSettings fakeLlvmConfig
+baseDynFlags = defaultDynFlags fakeSettings

--- a/src/Ormolu.hs
+++ b/src/Ormolu.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -46,13 +45,13 @@ where
 import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO (..))
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Debug.Trace
-import qualified GHC.Driver.CmdLine as GHC
-import qualified GHC.Types.SrcLoc as GHC
+import GHC.Driver.CmdLine qualified as GHC
+import GHC.Types.SrcLoc
 import Ormolu.Config
 import Ormolu.Diff.ParseResult
 import Ormolu.Diff.Text
@@ -63,7 +62,7 @@ import Ormolu.Parser.CommentStream (showCommentStream)
 import Ormolu.Parser.Result
 import Ormolu.Printer
 import Ormolu.Utils (showOutputable)
-import qualified Ormolu.Utils.Cabal as CabalUtils
+import Ormolu.Utils.Cabal qualified as CabalUtils
 import Ormolu.Utils.Fixity (getFixityOverridesForSourceFile)
 import Ormolu.Utils.IO
 import System.FilePath
@@ -228,7 +227,7 @@ parseModule' ::
   -- | Fixity Map for operators
   LazyFixityMap ->
   -- | How to obtain 'OrmoluException' to throw when parsing fails
-  (GHC.SrcSpan -> String -> OrmoluException) ->
+  (SrcSpan -> String -> OrmoluException) ->
   -- | File name to use in errors
   FilePath ->
   -- | Actual input for the parser
@@ -245,7 +244,7 @@ showWarn :: GHC.Warn -> String
 showWarn (GHC.Warn reason l) =
   unlines
     [ showOutputable reason,
-      showOutputable l
+      unLoc l
     ]
 
 -- | Detect 'SourceType' based on the file extension.

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -56,17 +54,17 @@ where
 
 import Control.Monad (forM)
 import Data.Aeson ((.!=), (.:?))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Types as Aeson
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
 import Data.Functor.Identity (Identity (..))
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.String (fromString)
-import qualified Data.Yaml as Yaml
+import Data.Yaml qualified as Yaml
 import Distribution.Types.PackageName (PackageName)
 import GHC.Generics (Generic)
-import qualified GHC.Types.SrcLoc as GHC
+import GHC.Types.SrcLoc qualified as GHC
 import Ormolu.Config.Gen
 import Ormolu.Fixity (FixityMap)
 import Ormolu.Fixity.Parser (parseFixityDeclaration)

--- a/src/Ormolu/Fixity.hs
+++ b/src/Ormolu/Fixity.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -27,27 +26,25 @@ module Ormolu.Fixity
   )
 where
 
-import qualified Data.Binary as Binary
-import qualified Data.Binary.Get as Binary
-import qualified Data.ByteString.Lazy as BL
+import Data.Binary qualified as Binary
+import Data.Binary.Get qualified as Binary
+import Data.ByteString.Lazy qualified as BL
 import Data.Foldable (foldl')
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.MemoTrie (memo)
 import Data.Semigroup (sconcat)
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Distribution.Types.PackageName (PackageName, mkPackageName, unPackageName)
 import Ormolu.Fixity.Internal
 #if BUNDLE_FIXITIES
 import Data.FileEmbed (embedFile)
 #else
-import qualified Data.ByteString.Unsafe as BU
-import Foreign.Ptr
-import System.Environment (getEnv)
+import qualified Data.ByteString as B
 import System.IO.Unsafe (unsafePerformIO)
 #endif
 
@@ -59,12 +56,10 @@ HackageInfo packageToOps packageToPopularity =
     BL.fromStrict $(embedFile "extract-hackage-info/hackage-info.bin")
 #else
 -- The GHC WASM backend does not yet support Template Haskell, so we instead
--- pass in the encoded fixity DB at runtime by storing the pointer and length of
--- the bytes in an environment variable.
-HackageInfo packageToOps packageToPopularity = unsafePerformIO $ do
-  (ptr, len) <- read <$> getEnv "ORMOLU_HACKAGE_INFO"
-  Binary.runGet Binary.get . BL.fromStrict
-    <$> BU.unsafePackMallocCStringLen (intPtrToPtr $ IntPtr ptr, len)
+-- pass in the encoded fixity DB via pre-initialization with Wizer.
+HackageInfo packageToOps packageToPopularity =
+  unsafePerformIO $
+    Binary.runGet Binary.get . BL.fromStrict <$> B.readFile "hackage-info.bin"
 {-# NOINLINE packageToOps #-}
 {-# NOINLINE packageToPopularity #-}
 #endif

--- a/src/Ormolu/Fixity/Internal.hs
+++ b/src/Ormolu/Fixity/Internal.hs
@@ -1,11 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Ormolu.Fixity.Internal
@@ -24,16 +19,17 @@ module Ormolu.Fixity.Internal
   )
 where
 
+import Control.DeepSeq (NFData)
 import Data.Binary (Binary)
 import Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short as SBS
+import Data.ByteString.Short qualified as SBS
 import Data.Foldable (asum)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.String (IsString (..))
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import Distribution.Types.PackageName (PackageName)
 import GHC.Data.FastString (fs_sbs)
 import GHC.Generics (Generic)
@@ -45,7 +41,7 @@ data FixityDirection
   | InfixR
   | InfixN
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (Binary)
+  deriving anyclass (Binary, NFData)
 
 -- | Fixity information about an infix operator that takes the uncertainty
 -- that can arise from conflicting definitions into account.
@@ -60,7 +56,7 @@ data FixityInfo = FixityInfo
     fiMaxPrecedence :: Int
   }
   deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass (Binary)
+  deriving anyclass (Binary, NFData)
 
 -- | The lowest level of information we can have about an operator.
 defaultFixityInfo :: FixityInfo
@@ -100,7 +96,7 @@ newtype OpName = MkOpName
   { -- | Invariant: UTF-8 encoded
     getOpName :: ShortByteString
   }
-  deriving newtype (Eq, Ord, Binary)
+  deriving newtype (Eq, Ord, Binary, NFData)
 
 -- | Convert an 'OpName' to 'Text'.
 unOpName :: OpName -> Text
@@ -140,9 +136,9 @@ lookupFixity op (LazyFixityMap maps) = asum (Map.lookup op <$> maps)
 -- each package, if available.
 data HackageInfo
   = HackageInfo
+      -- | Map from package name to a map from operator name to its fixity
       (Map PackageName FixityMap)
-      -- ^ Map from package name to a map from operator name to its fixity
+      -- | Map from package name to its 30-days download count from Hackage
       (Map PackageName Int)
-      -- ^ Map from package name to its 30-days download count from Hackage
   deriving stock (Generic)
   deriving anyclass (Binary)

--- a/src/Ormolu/Fixity/Parser.hs
+++ b/src/Ormolu/Fixity/Parser.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
 
 -- | Parser for fixity maps.
 module Ormolu.Fixity.Parser
@@ -13,15 +12,15 @@ module Ormolu.Fixity.Parser
   )
 where
 
-import qualified Data.Char as Char
-import qualified Data.Map.Strict as Map
+import Data.Char qualified as Char
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Void (Void)
 import Ormolu.Fixity
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Text.Megaparsec.Char.Lexer qualified as L
 
 type Parser = Parsec Void Text
 

--- a/src/Ormolu/Fixity/Printer.hs
+++ b/src/Ormolu/Fixity/Printer.hs
@@ -7,14 +7,14 @@ module Ormolu.Fixity.Printer
   )
 where
 
-import qualified Data.Char as Char
-import qualified Data.Map.Strict as Map
+import Data.Char qualified as Char
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Builder (Builder)
-import qualified Data.Text.Lazy.Builder as B
-import qualified Data.Text.Lazy.Builder.Int as B
+import Data.Text.Lazy.Builder qualified as B
+import Data.Text.Lazy.Builder.Int qualified as B
 import Ormolu.Fixity
 
 -- | Print out a textual representation of a 'FixityMap'.

--- a/src/Ormolu/Parser/CommentStream.hs
+++ b/src/Ormolu/Parser/CommentStream.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- | Functions for working with comment stream.
@@ -26,19 +22,19 @@ import Data.Char (isSpace)
 import Data.Data (Data)
 import Data.Generics.Schemes
 import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Lazy as M
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Lazy qualified as M
 import Data.Maybe
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified GHC.Data.Strict as Strict
+import Data.Text qualified as T
+import GHC.Data.Strict qualified as Strict
 import GHC.Hs (HsModule)
 import GHC.Hs.Doc
 import GHC.Hs.Extension
 import GHC.Hs.ImpExp
 import GHC.Parser.Annotation (EpAnnComments (..), getLocA)
-import qualified GHC.Parser.Annotation as GHC
+import GHC.Parser.Annotation qualified as GHC
 import GHC.Types.SrcLoc
 import Ormolu.Parser.Pragma
 import Ormolu.Utils (onTheSameLine, showOutputable)
@@ -57,7 +53,7 @@ mkCommentStream ::
   -- | Original input
   Text ->
   -- | Module to use for comment extraction
-  HsModule ->
+  HsModule GhcPs ->
   -- | Stack header, pragmas, and comment stream
   ( Maybe (RealLocated Comment),
     [([RealLocated Comment], Pragma)],

--- a/src/Ormolu/Parser/Pragma.hs
+++ b/src/Ormolu/Parser/Pragma.hs
@@ -10,12 +10,12 @@ where
 
 import Data.Char (isSpace)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import GHC.Data.FastString (bytesFS, mkFastString)
 import GHC.Driver.Config.Parser (initParserOpts)
 import GHC.DynFlags (baseDynFlags)
-import qualified GHC.Parser.Lexer as L
+import GHC.Parser.Lexer qualified as L
 import GHC.Types.SrcLoc
 import Ormolu.Utils (textToStringBuffer)
 

--- a/src/Ormolu/Parser/Result.hs
+++ b/src/Ormolu/Parser/Result.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
 -- | A type for result of parsing.
 module Ormolu.Parser.Result
   ( SourceSnippet (..),
@@ -23,7 +21,7 @@ data SourceSnippet = RawSnippet Text | ParsedSnippet ParseResult
 -- | A collection of data that represents a parsed module in Ormolu.
 data ParseResult = ParseResult
   { -- | Parsed module or signature
-    prParsedSource :: HsModule,
+    prParsedSource :: HsModule GhcPs,
     -- | Either regular module or signature file
     prSourceType :: SourceType,
     -- | Stack header

--- a/src/Ormolu/Printer.hs
+++ b/src/Ormolu/Printer.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Pretty-printer for Haskell AST.
@@ -10,7 +9,7 @@ module Ormolu.Printer
 where
 
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Ormolu.Config
 import Ormolu.Parser.Result
 import Ormolu.Printer.Combinators

--- a/src/Ormolu/Printer/Combinators.hs
+++ b/src/Ormolu/Printer/Combinators.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -96,7 +95,7 @@ where
 import Control.Monad
 import Data.List (intersperse)
 import Data.Text (Text)
-import qualified GHC.Data.Strict as Strict
+import GHC.Data.Strict qualified as Strict
 import GHC.LanguageExtensions.Type
 import GHC.Types.SrcLoc
 import Ormolu.Config

--- a/src/Ormolu/Printer/Comments.hs
+++ b/src/Ormolu/Printer/Comments.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Helpers for formatting of comments. This is low-level code, use
@@ -13,7 +12,7 @@ module Ormolu.Printer.Comments
 where
 
 import Control.Monad
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (listToMaybe)
 import GHC.Types.SrcLoc
 import Ormolu.Parser.CommentStream

--- a/src/Ormolu/Printer/Internal.hs
+++ b/src/Ormolu/Printer/Internal.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 
 -- | In most cases import "Ormolu.Printer.Combinators" instead, these
 -- functions are the low-level building blocks and should not be used on
@@ -69,11 +67,11 @@ import Data.Coerce
 import Data.Functor.Identity (runIdentity)
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Builder
 import GHC.Data.EnumSet (EnumSet)
-import qualified GHC.Data.EnumSet as EnumSet
+import GHC.Data.EnumSet qualified as EnumSet
 import GHC.LanguageExtensions.Type
 import GHC.Types.SrcLoc
 import GHC.Utils.Outputable (Outputable)

--- a/src/Ormolu/Printer/Meat/Common.hs
+++ b/src/Ormolu/Printer/Meat/Common.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Rendering of commonly useful bits.
@@ -18,7 +17,7 @@ where
 
 import Control.Monad
 import Data.Foldable (traverse_)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import GHC.Hs.Doc
 import GHC.Hs.Extension (GhcPs)
 import GHC.Hs.ImpExp
@@ -27,7 +26,7 @@ import GHC.Types.Name.Occurrence (OccName (..))
 import GHC.Types.Name.Reader
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
-import GHC.Unit.Module.Name
+import Language.Haskell.Syntax.Module.Name
 import Ormolu.Config
 import Ormolu.Printer.Combinators
 import Ormolu.Utils
@@ -49,9 +48,9 @@ p_hsmodName mname = do
   space
   atom mname
 
-p_ieWrappedName :: IEWrappedName RdrName -> R ()
+p_ieWrappedName :: IEWrappedName GhcPs -> R ()
 p_ieWrappedName = \case
-  IEName x -> p_rdrName x
+  IEName _ x -> p_rdrName x
   IEPattern _ x -> do
     txt "pattern"
     space
@@ -235,4 +234,4 @@ p_hsDoc' poHStyle hstyle needsNewline (L l str) = do
 p_sourceText :: SourceText -> R ()
 p_sourceText = \case
   NoSourceText -> pure ()
-  SourceText s -> space >> txt (T.pack s)
+  SourceText s -> txt (T.pack s)

--- a/src/Ormolu/Printer/Meat/Declaration.hs
+++ b/src/Ormolu/Printer/Meat/Declaration.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -13,7 +12,7 @@ where
 
 import Data.List (sort)
 import Data.List.NonEmpty (NonEmpty (..), (<|))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import GHC.Hs
 import GHC.Types.Name.Occurrence (occNameFS)
 import GHC.Types.Name.Reader
@@ -254,12 +253,12 @@ pattern
     RdrName -> HsDecl GhcPs
 pattern InlinePragma n <- SigD _ (InlineSig _ (L _ n) _)
 pattern SpecializePragma n <- SigD _ (SpecSig _ (L _ n) _ _)
-pattern SCCPragma n <- SigD _ (SCCFunSig _ _ (L _ n) _)
-pattern AnnTypePragma n <- AnnD _ (HsAnnotation _ _ (TypeAnnProvenance (L _ n)) _)
-pattern AnnValuePragma n <- AnnD _ (HsAnnotation _ _ (ValueAnnProvenance (L _ n)) _)
+pattern SCCPragma n <- SigD _ (SCCFunSig _ (L _ n) _)
+pattern AnnTypePragma n <- AnnD _ (HsAnnotation _ (TypeAnnProvenance (L _ n)) _)
+pattern AnnValuePragma n <- AnnD _ (HsAnnotation _ (ValueAnnProvenance (L _ n)) _)
 pattern Pattern n <- ValD _ (PatSynBind _ (PSB _ (L _ n) _ _ _))
 pattern DataDeclaration n <- TyClD _ (DataDecl _ (L _ n) _ _ _)
-pattern ClassDeclaration n <- TyClD _ (ClassDecl _ _ (L _ n) _ _ _ _ _ _ _ _)
+pattern ClassDeclaration n <- TyClD _ (ClassDecl _ _ _ (L _ n) _ _ _ _ _ _ _ _)
 pattern KindSignature n <- KindSigD _ (StandaloneKindSig _ (L _ n) _)
 pattern FamilyDeclaration n <- TyClD _ (FamDecl _ (FamilyDecl _ _ _ (L _ n) _ _ _ _))
 pattern TypeSynonym n <- TyClD _ (SynDecl _ (L _ n) _ _ _)
@@ -294,8 +293,8 @@ defSigRdrNames (SigD _ (ClassOpSig _ True ns _)) = Just $ map unLoc ns
 defSigRdrNames _ = Nothing
 
 funRdrNames :: HsDecl GhcPs -> Maybe [RdrName]
-funRdrNames (ValD _ (FunBind _ (L _ n) _ _)) = Just [n]
-funRdrNames (ValD _ (PatBind _ (L _ n) _ _)) = Just $ patBindNames n
+funRdrNames (ValD _ (FunBind _ (L _ n) _)) = Just [n]
+funRdrNames (ValD _ (PatBind _ (L _ n) _)) = Just $ patBindNames n
 funRdrNames _ = Nothing
 
 patSigRdrNames :: HsDecl GhcPs -> Maybe [RdrName]
@@ -303,7 +302,7 @@ patSigRdrNames (SigD _ (PatSynSig _ ns _)) = Just $ map unLoc ns
 patSigRdrNames _ = Nothing
 
 warnSigRdrNames :: HsDecl GhcPs -> Maybe [RdrName]
-warnSigRdrNames (WarningD _ (Warnings _ _ ws)) = Just $
+warnSigRdrNames (WarningD _ (Warnings _ ws)) = Just $
   flip concatMap ws $
     \(L _ (Warning _ ns _)) -> map unLoc ns
 warnSigRdrNames _ = Nothing
@@ -316,7 +315,7 @@ patBindNames (LazyPat _ (L _ p)) = patBindNames p
 patBindNames (BangPat _ (L _ p)) = patBindNames p
 patBindNames (ParPat _ _ (L _ p) _) = patBindNames p
 patBindNames (ListPat _ ps) = concatMap (patBindNames . unLoc) ps
-patBindNames (AsPat _ (L _ n) (L _ p)) = n : patBindNames p
+patBindNames (AsPat _ (L _ n) _ (L _ p)) = n : patBindNames p
 patBindNames (SumPat _ (L _ p) _ _) = patBindNames p
 patBindNames (ViewPat _ _ (L _ p)) = patBindNames p
 patBindNames (SplicePat _ _) = []

--- a/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Annotation.hs
@@ -12,7 +12,7 @@ import Ormolu.Printer.Meat.Common
 import Ormolu.Printer.Meat.Declaration.Value
 
 p_annDecl :: AnnDecl GhcPs -> R ()
-p_annDecl (HsAnnotation _ _ annProv expr) =
+p_annDecl (HsAnnotation _ annProv expr) =
   pragma "ANN" . inci $ do
     p_annProv annProv
     breakpoint

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -14,7 +14,7 @@ import Control.Monad
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Maybe (isJust, maybeToList)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Void
 import GHC.Data.Strict qualified as Strict
 import GHC.Hs

--- a/src/Ormolu/Printer/Meat/Declaration/Default.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Default.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Ormolu.Printer.Meat.Declaration.Default

--- a/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Foreign.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Ormolu.Printer.Meat.Declaration.Foreign
@@ -50,18 +49,20 @@ p_foreignTypeSig fd = do
 -- We also layout the identifier using the 'SourceText', because printing
 -- with the other two fields of 'CImport' is very complicated. See the
 -- 'Outputable' instance of 'ForeignImport' for details.
-p_foreignImport :: ForeignImport -> R ()
-p_foreignImport (CImport cCallConv safety _ _ sourceText) = do
+p_foreignImport :: ForeignImport GhcPs -> R ()
+p_foreignImport (CImport sourceText cCallConv safety _ _) = do
   txt "foreign import"
   space
   located cCallConv atom
   -- Need to check for 'noLoc' for the 'safe' annotation
   when (isGoodSrcSpan $ getLoc safety) (space >> atom safety)
+  space
   located sourceText p_sourceText
 
-p_foreignExport :: ForeignExport -> R ()
-p_foreignExport (CExport (L loc (CExportStatic _ _ cCallConv)) sourceText) = do
+p_foreignExport :: ForeignExport GhcPs -> R ()
+p_foreignExport (CExport sourceText (L loc (CExportStatic _ _ cCallConv))) = do
   txt "foreign export"
   space
   located (L loc cCallConv) atom
+  space
   located sourceText p_sourceText

--- a/src/Ormolu/Printer/Meat/Declaration/Instance.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Instance.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/src/Ormolu/Printer/Meat/Declaration/OpTree.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/OpTree.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE PatternSynonyms #-}
 
 -- | Printing of operator trees.
 module Ormolu.Printer.Meat.Declaration.OpTree

--- a/src/Ormolu/Printer/Meat/Declaration/Rule.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Rule.hs
@@ -18,7 +18,7 @@ import Ormolu.Printer.Meat.Declaration.Value
 import Ormolu.Printer.Meat.Type
 
 p_ruleDecls :: RuleDecls GhcPs -> R ()
-p_ruleDecls (HsRules _ _ xs) =
+p_ruleDecls (HsRules _ xs) =
   pragma "RULES" $ sep breakpoint (sitcc . located' p_ruleDecl) xs
 
 p_ruleDecl :: RuleDecl GhcPs -> R ()
@@ -46,8 +46,8 @@ p_ruleDecl (HsRule _ ruleName activation tyvars ruleBndrs lhs rhs) = do
       breakpoint
       located rhs p_hsExpr
 
-p_ruleName :: (SourceText, RuleName) -> R ()
-p_ruleName (_, name) = atom $ (HsString NoSourceText name :: HsLit GhcPs)
+p_ruleName :: RuleName -> R ()
+p_ruleName name = atom (HsString NoSourceText name :: HsLit GhcPs)
 
 p_ruleBndr :: RuleBndr GhcPs -> R ()
 p_ruleBndr = \case

--- a/src/Ormolu/Printer/Meat/Declaration/Signature.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Signature.hs
@@ -32,11 +32,10 @@ p_sigDecl = \case
   FixSig _ sig -> p_fixSig sig
   InlineSig _ name inlinePragma -> p_inlineSig name inlinePragma
   SpecSig _ name ts inlinePragma -> p_specSig name ts inlinePragma
-  SpecInstSig _ _ sigType -> p_specInstSig sigType
-  MinimalSig _ _ booleanFormula -> p_minimalSig booleanFormula
-  CompleteMatchSig _ _sourceText cs ty -> p_completeSig cs ty
-  SCCFunSig _ _ name literal -> p_sccSig name literal
-  _ -> notImplemented "certain types of signature declarations"
+  SpecInstSig _ sigType -> p_specInstSig sigType
+  MinimalSig _ booleanFormula -> p_minimalSig booleanFormula
+  CompleteMatchSig _ cs ty -> p_completeSig cs ty
+  SCCFunSig _ name literal -> p_sccSig name literal
 
 p_typeSig ::
   -- | Should the tail of the names be indented

--- a/src/Ormolu/Printer/Meat/Declaration/Splice.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Splice.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 module Ormolu.Printer.Meat.Declaration.Splice
   ( p_spliceDecl,
   )
@@ -7,8 +5,8 @@ where
 
 import GHC.Hs
 import Ormolu.Printer.Combinators
-import Ormolu.Printer.Meat.Declaration.Value (p_hsSplice)
+import Ormolu.Printer.Meat.Declaration.Value (p_hsUntypedSplice)
 
 p_spliceDecl :: SpliceDecl GhcPs -> R ()
-p_spliceDecl = \case
-  SpliceDecl NoExtField splice _explicit -> located splice p_hsSplice
+p_spliceDecl (SpliceDecl NoExtField splice deco) =
+  located splice $ p_hsUntypedSplice deco

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1,19 +1,15 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Ormolu.Printer.Meat.Declaration.Value
   ( p_valDecl,
     p_pat,
     p_hsExpr,
-    p_hsSplice,
+    p_hsUntypedSplice,
     p_stringLit,
     p_hsExpr',
     p_hsCmdTop,
@@ -31,14 +27,13 @@ import Data.Functor ((<&>))
 import Data.Generics.Schemes (everything)
 import Data.List (find, intersperse, sortBy)
 import Data.List.NonEmpty (NonEmpty (..), (<|))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Void
 import GHC.Data.Bag (bagToList)
-import GHC.Data.FastString (FastString, lengthFS)
-import qualified GHC.Data.Strict as Strict
+import GHC.Data.Strict qualified as Strict
 import GHC.Hs
 import GHC.LanguageExtensions.Type (Extension (NegativeLiterals))
 import GHC.Parser.CharClass (is_space)
@@ -47,6 +42,7 @@ import GHC.Types.Fixity
 import GHC.Types.Name.Reader
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
+import Language.Haskell.Syntax.Basic
 import Ormolu.Config
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Internal (sitccIfTrailing)
@@ -73,8 +69,8 @@ data GroupStyle
 
 p_valDecl :: HsBind GhcPs -> R ()
 p_valDecl = \case
-  FunBind _ funId funMatches _ -> p_funBind funId funMatches
-  PatBind _ pat grhss _ -> p_match PatternBind False NoSrcStrict [pat] grhss
+  FunBind _ funId funMatches -> p_funBind funId funMatches
+  PatBind _ pat grhss -> p_match PatternBind False NoSrcStrict [pat] grhss
   VarBind {} -> notImplemented "VarBinds" -- introduced by the type checker
   PatSynBind _ psb -> p_patSynBind psb
 
@@ -554,21 +550,8 @@ p_hsLocalBinds = \case
       _ -> id
 
 p_ldotFieldOcc :: XRec GhcPs (DotFieldOcc GhcPs) -> R ()
-p_ldotFieldOcc = located' $ p_lFieldLabelString . dfoLabel
-  where
-    p_lFieldLabelString (L (locA -> s) fs) = parensIfOp . atom @FastString $ fs
-      where
-        -- HACK For OverloadedRecordUpdate:
-        -- In operator field updates (i.e. `f {(+) = 1}`), we don't have
-        -- information whether parens are necessary. As a workaround,
-        -- we look if the RealSrcSpan is bigger than the string fs.
-        parensIfOp
-          | isOneLineSpan s,
-            Just realS <- srcSpanToRealSrcSpan s,
-            let spanLength = srcSpanEndCol realS - srcSpanStartCol realS,
-            lengthFS fs < spanLength =
-              parens N
-          | otherwise = id
+p_ldotFieldOcc =
+  located' $ p_rdrName . fmap (mkVarUnqual . field_label) . dfoLabel
 
 p_ldotFieldOccs :: [XRec GhcPs (DotFieldOcc GhcPs)] -> R ()
 p_ldotFieldOccs = sep (txt ".") p_ldotFieldOcc
@@ -600,9 +583,9 @@ p_hsExpr' s = \case
   HsVar _ name -> p_rdrName name
   HsUnboundVar _ occ -> atom occ
   HsRecSel _ fldOcc -> p_fieldOcc fldOcc
-  HsOverLabel _ v -> do
+  HsOverLabel _ sourceText _ -> do
     txt "#"
-    atom v
+    p_sourceText sourceText
   HsIPVar _ (HsIPName name) -> do
     txt "?"
     atom name
@@ -678,7 +661,7 @@ p_hsExpr' s = \case
           sep breakpoint (located' p_hsExpr) initp
         placeHanging placement . dontUseBraces $
           located lastp p_hsExpr
-  HsAppType _ e a -> do
+  HsAppType _ e _ a -> do
     located e p_hsExpr
     breakpoint
     inci $ do
@@ -849,7 +832,8 @@ p_hsExpr' s = \case
     breakpoint'
     txt "||]"
   HsUntypedBracket epAnn x -> p_hsQuote epAnn x
-  HsSpliceE _ splice -> p_hsSplice splice
+  HsTypedSplice _ expr -> p_hsSpliceTH True expr DollarSplice
+  HsUntypedSplice _ untySplice -> p_hsUntypedSplice DollarSplice untySplice
   HsProc _ p e -> do
     txt "proc"
     located p $ \x -> do
@@ -864,7 +848,7 @@ p_hsExpr' s = \case
     breakpoint
     inci (located e p_hsExpr)
   HsPragE _ prag x -> case prag of
-    HsPragSCC _ _ name -> do
+    HsPragSCC _ name -> do
       txt "{-# SCC "
       atom name
       txt " #-}"
@@ -1103,7 +1087,7 @@ p_pat = \case
   LazyPat _ pat -> do
     txt "~"
     located pat p_pat
-  AsPat _ name pat -> do
+  AsPat _ name _ pat -> do
     p_rdrName name
     txt "@"
     located pat p_pat
@@ -1128,7 +1112,7 @@ p_pat = \case
         p_rdrName pat
         unless (null tys && null xs) breakpoint
         inci . sitcc $
-          sep breakpoint (sitcc . either p_hsPatSigType (located' p_pat)) $
+          sep breakpoint (sitcc . either p_hsConPatTyArg (located' p_pat)) $
             (Left <$> tys) <> (Right <$> xs)
       RecCon (HsRecFields fields dotdot) -> do
         p_rdrName pat
@@ -1139,7 +1123,7 @@ p_pat = \case
         inci . braces N . sep commaDel f $
           case dotdot of
             Nothing -> Just <$> fields
-            Just (L _ n) -> (Just <$> take n fields) ++ [Nothing]
+            Just (L _ (RecFieldsDotDot n)) -> (Just <$> take n fields) ++ [Nothing]
       InfixCon l r -> do
         switchLayout [getLocA l, getLocA r] $ do
           located l p_pat
@@ -1154,7 +1138,7 @@ p_pat = \case
     token'rarrow
     breakpoint
     inci (located pat p_pat)
-  SplicePat _ splice -> p_hsSplice splice
+  SplicePat _ splice -> p_hsUntypedSplice DollarSplice splice
   LitPat _ p -> atom p
   NPat _ v (isJust -> isNegated) _ -> do
     when isNegated $ do
@@ -1175,6 +1159,9 @@ p_pat = \case
 
 p_hsPatSigType :: HsPatSigType GhcPs -> R ()
 p_hsPatSigType (HsPS _ ty) = txt "@" *> located ty p_hsType
+
+p_hsConPatTyArg :: HsConPatTyArg GhcPs -> R ()
+p_hsConPatTyArg (HsConPatTyArg _ patSigTy) = p_hsPatSigType patSigTy
 
 p_pat_hsFieldBind :: HsRecField GhcPs (LPat GhcPs) -> R ()
 p_pat_hsFieldBind HsFieldBind {..} = do
@@ -1200,11 +1187,10 @@ p_unboxedSum s tag arity m = do
             space
   parensHash s $ sep (txt "|") f args
 
-p_hsSplice :: HsSplice GhcPs -> R ()
-p_hsSplice = \case
-  HsTypedSplice _ deco _ expr -> p_hsSpliceTH True expr deco
-  HsUntypedSplice _ deco _ expr -> p_hsSpliceTH False expr deco
-  HsQuasiQuote _ _ quoterName _ str -> do
+p_hsUntypedSplice :: SpliceDecoration -> HsUntypedSplice GhcPs -> R ()
+p_hsUntypedSplice deco = \case
+  HsUntypedSpliceExpr _ expr -> p_hsSpliceTH False expr deco
+  HsQuasiQuote _ quoterName str -> do
     txt "["
     p_rdrName (noLocA quoterName)
     txt "|"
@@ -1212,7 +1198,6 @@ p_hsSplice = \case
     -- formatting here without potentially breaking someone's code.
     atom str
     txt "|]"
-  HsSpliced {} -> notImplemented "HsSpliced"
 
 p_hsSpliceTH ::
   -- | Typed splice?
@@ -1365,7 +1350,7 @@ exprPlacement :: HsExpr GhcPs -> Placement
 exprPlacement = \case
   -- Only hang lambdas with single line parameter lists
   HsLam _ mg -> case mg of
-    MG _ (L _ [L _ (Match _ _ (x : xs) _)]) _
+    MG _ (L _ [L _ (Match _ _ (x : xs) _)])
       | isOneLineSpan (combineSrcSpans' $ fmap getLocA (x :| xs)) ->
           Hanging
     _ -> Normal

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
@@ -2,7 +2,7 @@ module Ormolu.Printer.Meat.Declaration.Value
   ( p_valDecl,
     p_pat,
     p_hsExpr,
-    p_hsSplice,
+    p_hsUntypedSplice,
     p_stringLit,
     p_hsExpr',
     p_hsCmdTop,
@@ -11,16 +11,13 @@ module Ormolu.Printer.Meat.Declaration.Value
   )
 where
 
-import GHC.Hs.Binds
-import GHC.Hs.Expr
-import GHC.Hs.Extension
-import GHC.Hs.Pat
+import GHC.Hs
 import Ormolu.Printer.Combinators
 
 p_valDecl :: HsBindLR GhcPs GhcPs -> R ()
 p_pat :: Pat GhcPs -> R ()
 p_hsExpr :: HsExpr GhcPs -> R ()
-p_hsSplice :: HsSplice GhcPs -> R ()
+p_hsUntypedSplice :: SpliceDecoration -> HsUntypedSplice GhcPs -> R ()
 p_stringLit :: String -> R ()
 p_hsExpr' :: BracketStyle -> HsExpr GhcPs -> R ()
 p_hsCmdTop :: BracketStyle -> HsCmdTop GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/Declaration/Warning.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Warning.hs
@@ -18,7 +18,7 @@ import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 
 p_warnDecls :: WarnDecls GhcPs -> R ()
-p_warnDecls (Warnings _ _ warnings) =
+p_warnDecls (Warnings _ warnings) =
   traverse_ (located' p_warnDecl) warnings
 
 p_warnDecl :: WarnDecl GhcPs -> R ()

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -10,12 +10,11 @@ module Ormolu.Printer.Meat.ImportExport
 where
 
 import Control.Monad
-import qualified Data.Text as T
+import Data.Text qualified as T
 import GHC.Hs
 import GHC.LanguageExtensions.Type
 import GHC.Types.PkgQual
 import GHC.Types.SrcLoc
-import GHC.Unit.Types
 import Ormolu.Config
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
@@ -64,13 +63,12 @@ p_hsmodImport ImportDecl {..} = do
         space
         located l atom
     space
-    case ideclHiding of
+    case ideclImportList of
       Nothing -> return ()
-      Just (hiding, _) ->
-        when hiding (txt "hiding")
-    case ideclHiding of
-      Nothing -> return ()
-      Just (_, L _ xs) -> do
+      Just (hiding, L _ xs) -> do
+        case hiding of
+          Exactly -> pure ()
+          EverythingBut -> txt "hiding"
         breakIfNotDiffFriendly
         parens' True $ do
           layout <- getLayout

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -10,7 +11,6 @@ where
 import Control.Monad
 import GHC.Hs hiding (comment)
 import GHC.Types.SrcLoc
-import GHC.Unit.Module.Name
 import GHC.Utils.Outputable (ppr, showSDocUnsafe)
 import Ormolu.Config
 import Ormolu.Imports (normalizeImports)
@@ -58,8 +58,8 @@ p_hsModule mstackHeader pragmas hsmod@HsModule {..} = do
       newline
       spitRemainingComments
 
-p_hsModuleHeader :: HsModule -> LocatedA ModuleName -> R ()
-p_hsModuleHeader HsModule {..} moduleName = do
+p_hsModuleHeader :: HsModule GhcPs -> LocatedA ModuleName -> R ()
+p_hsModuleHeader HsModule {hsmodExt = XModulePs {..}, ..} moduleName = do
   located moduleName $ \name -> do
     poHStyle <-
       getPrinterOpt poHaddockStyleModule >>= \case

--- a/src/Ormolu/Printer/Meat/Module.hs
+++ b/src/Ormolu/Printer/Meat/Module.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -33,10 +32,11 @@ p_hsModule ::
   -- | Pragmas and the associated comments
   [([RealLocated Comment], Pragma)] ->
   -- | AST to print
-  HsModule ->
+  HsModule GhcPs ->
   R ()
 p_hsModule mstackHeader pragmas hsmod@HsModule {..} = do
-  let deprecSpan = maybe [] (pure . getLocA) hsmodDeprecMessage
+  let XModulePs {..} = hsmodExt
+      deprecSpan = maybe [] (pure . getLocA) hsmodDeprecMessage
       exportSpans = maybe [] (pure . getLocA) hsmodExports
   switchLayout (deprecSpan <> exportSpans) $ do
     forM_ mstackHeader $ \(L spn comment) -> do

--- a/src/Ormolu/Printer/Meat/Pragma.hs
+++ b/src/Ormolu/Printer/Meat/Pragma.hs
@@ -9,11 +9,11 @@ where
 
 import Control.Monad
 import Data.Char (isUpper)
-import qualified Data.List as L
+import Data.List qualified as L
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import GHC.Driver.Flags (Language)
 import GHC.Types.SrcLoc
 import Ormolu.Parser.CommentStream

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Rendering of types.
 module Ormolu.Printer.Meat.Type
   ( p_hsType,
-    p_hsTypePostDoc,
     startTypeAnnotation,
     startTypeAnnotationDecl,
     hasDocStrings,
@@ -25,8 +23,7 @@ module Ormolu.Printer.Meat.Type
 where
 
 import Control.Monad
-import GHC.Hs
-import GHC.Types.Basic hiding (isPromoted)
+import GHC.Hs hiding (isPromoted)
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
 import GHC.Types.Var
@@ -34,30 +31,17 @@ import Ormolu.Config
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.OpTree (p_tyOpTree, tyOpTree)
-import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsSplice, p_stringLit)
+import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsUntypedSplice, p_stringLit)
 import Ormolu.Printer.Operators
 import Ormolu.Utils
 
 p_hsType :: HsType GhcPs -> R ()
 p_hsType t = do
-  s <-
-    getPrinterOpt poFunctionArrows >>= \case
-      TrailingArrows -> pure PipeStyle
-      LeadingArrows -> pure CaretStyle
-      LeadingArgsArrows -> pure CaretStyle
   layout <- getLayout
-  p_hsType' (hasDocStrings t || layout == MultiLine) s t
+  p_hsType' (hasDocStrings t || layout == MultiLine) t
 
-p_hsTypePostDoc :: HsType GhcPs -> R ()
-p_hsTypePostDoc t = p_hsType' (hasDocStrings t) CaretStyle t
-
--- | How to render Haddocks associated with a type.
-data TypeDocStyle
-  = PipeStyle
-  | CaretStyle
-
-p_hsType' :: Bool -> TypeDocStyle -> HsType GhcPs -> R ()
-p_hsType' multilineArgs docStyle = \case
+p_hsType' :: Bool -> HsType GhcPs -> R ()
+p_hsType' multilineArgs = \case
   HsForAllTy _ tele t -> do
     vis <-
       case tele of
@@ -150,16 +134,10 @@ p_hsType' multilineArgs docStyle = \case
   HsKindSig _ t k -> sitcc $ do
     located t p_hsType
     inci $ startTypeAnnotation k p_hsType
-  HsSpliceTy _ splice -> p_hsSplice splice
+  HsSpliceTy _ splice -> p_hsUntypedSplice DollarSplice splice
   HsDocTy _ t str ->
-    case docStyle of
-      PipeStyle -> do
-        p_hsDoc Pipe True str
-        located t p_hsType
-      CaretStyle -> do
-        located t p_hsType
-        newline
-        p_hsDoc Caret False str
+    p_hsDoc Pipe True str
+    located t p_hsType
   HsBangTy _ (HsSrcBang _ u s) t -> do
     case u of
       SrcUnpack -> txt "{-# UNPACK #-}" >> space
@@ -177,17 +155,17 @@ p_hsType' multilineArgs docStyle = \case
       IsPromoted -> txt "'"
       NotPromoted -> return ()
     brackets N $ do
-      -- If both this list itself and the first element is promoted,
-      -- we need to put a space in between or it fails to parse.
+      -- If this list is promoted and the first element starts with a single
+      -- quote, we need to put a space in between or it fails to parse.
       case (p, xs) of
-        (IsPromoted, L _ t : _) | isPromoted t -> space
+        (IsPromoted, L _ t : _) | startsWithSingleQuote t -> space
         _ -> return ()
       sep commaDel (sitcc . located' p_hsType) xs
   HsExplicitTupleTy _ xs -> do
     txt "'"
     parens N $ do
       case xs of
-        L _ t : _ | isPromoted t -> space
+        L _ t : _ | startsWithSingleQuote t -> space
         _ -> return ()
       sep commaDel (located' p_hsType) xs
   HsTyLit _ t ->
@@ -197,17 +175,18 @@ p_hsType' multilineArgs docStyle = \case
   HsWildCardTy _ -> txt "_"
   XHsType t -> atom t
   where
-    isPromoted = \case
-      HsAppTy _ (L _ f) _ -> isPromoted f
+    startsWithSingleQuote = \case
+      HsAppTy _ (L _ f) _ -> startsWithSingleQuote f
       HsTyVar _ IsPromoted _ -> True
       HsExplicitTupleTy {} -> True
       HsExplicitListTy {} -> True
+      HsTyLit _ HsCharTy {} -> True
       _ -> False
     interArgBreak =
       if multilineArgs
         then newline
         else breakpoint
-    p_hsTypeR m = p_hsType' multilineArgs docStyle m
+    p_hsTypeR m = p_hsType' multilineArgs m
 
 startTypeAnnotation ::
   (HasSrcSpan l) =>

--- a/src/Ormolu/Printer/Operators.hs
+++ b/src/Ormolu/Printer/Operators.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | This module helps handle operator chains composed of different
 -- operators that may have different precedence and fixities.
@@ -13,8 +12,8 @@ module Ormolu.Printer.Operators
 where
 
 import Control.Applicative ((<|>))
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Strict as Map
+import Data.List.NonEmpty qualified as NE
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import GHC.Types.Name.Reader
 import GHC.Types.SrcLoc

--- a/src/Ormolu/Processing/Common.hs
+++ b/src/Ormolu/Processing/Common.hs
@@ -13,9 +13,9 @@ where
 
 import Data.Char (isSpace)
 import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
+import Data.IntSet qualified as IntSet
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Ormolu.Config
 
 -- | Remove indentation from a given 'Text'. Return the input with indentation

--- a/src/Ormolu/Processing/Cpp.hs
+++ b/src/Ormolu/Processing/Cpp.hs
@@ -7,10 +7,10 @@ module Ormolu.Processing.Cpp
 where
 
 import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
+import Data.IntSet qualified as IntSet
 import Data.Maybe (isJust)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 -- | State of the CPP processor.
 data State

--- a/src/Ormolu/Processing/Preprocess.hs
+++ b/src/Ormolu/Processing/Preprocess.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -15,13 +14,13 @@ import Data.Bifunctor (bimap)
 import Data.Char (isSpace)
 import Data.Function ((&))
 import Data.IntMap (IntMap)
-import qualified Data.IntMap.Strict as IntMap
+import Data.IntMap.Strict qualified as IntMap
 import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
-import qualified Data.List as L
+import Data.IntSet qualified as IntSet
+import Data.List qualified as L
 import Data.Maybe (isJust)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Ormolu.Config (RegionDeltas (..))
 import Ormolu.Processing.Common
 import Ormolu.Processing.Cpp

--- a/src/Ormolu/Terminal.hs
+++ b/src/Ormolu/Terminal.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 -- | An abstraction for colorful output in terminal.
 module Ormolu.Terminal
-  ( -- * The 'Term' monad
+  ( -- * The 'Term' abstraction
     Term,
     ColorMode (..),
     runTerm,
+    runTermPure,
 
     -- * Styling
     bold,
@@ -17,35 +17,40 @@ module Ormolu.Terminal
 
     -- * Printing
     put,
-    putS,
-    putSrcSpan,
-    putRealSrcSpan,
+    putShow,
+    putOutputable,
     newline,
   )
 where
 
-import Control.Monad.Reader
+import Control.Applicative (Const (..))
+import Control.Monad (forM_)
+import Data.Foldable (toList)
+import Data.Sequence (Seq)
+import Data.Sequence qualified as Seq
 import Data.Text (Text)
-import qualified Data.Text.IO as T
-import GHC.Types.SrcLoc
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import GHC.Utils.Outputable (Outputable)
 import Ormolu.Utils (showOutputable)
 import System.Console.ANSI
-import System.IO (Handle, hFlush, hPutStr)
+import System.IO (Handle, hFlush)
 
 ----------------------------------------------------------------------------
--- The 'Term' monad
+-- The 'Term' abstraction
 
--- | Terminal monad.
-newtype Term a = Term (ReaderT RC IO a)
-  deriving (Functor, Applicative, Monad)
+type Term = TermOutput ()
 
--- | Reader context of 'Term'.
-data RC = RC
-  { -- | Whether to use colors
-    rcUseColor :: Bool,
-    -- | Handle to print to
-    rcHandle :: Handle
-  }
+newtype TermOutput a = TermOutput (Const (Seq TermOutputNode) a)
+  deriving (Semigroup, Monoid, Functor, Applicative)
+
+data TermOutputNode
+  = OutputText Text
+  | WithColor Color Term
+  | WithBold Term
+
+singleTerm :: TermOutputNode -> Term
+singleTerm = TermOutput . Const . Seq.singleton
 
 -- | Whether to use colors and other features of ANSI terminals.
 data ColorMode = Never | Always | Auto
@@ -53,78 +58,73 @@ data ColorMode = Never | Always | Auto
 
 -- | Run 'Term' monad.
 runTerm ::
-  -- | Monad to run
-  Term a ->
+  Term ->
   -- | Color mode
   ColorMode ->
   -- | Handle to print to
   Handle ->
-  IO a
-runTerm (Term m) colorMode rcHandle = do
-  rcUseColor <- case colorMode of
+  IO ()
+runTerm term0 colorMode handle = do
+  useSGR <- case colorMode of
     Never -> return False
     Always -> return True
-    Auto -> hSupportsANSI rcHandle
-  x <- runReaderT m RC {..}
-  hFlush rcHandle
-  return x
+    Auto -> hSupportsANSI handle
+  runTerm' useSGR term0
+  hFlush handle
+  where
+    runTerm' useSGR = go
+      where
+        go (TermOutput (Const nodes)) =
+          forM_ nodes $ \case
+            OutputText s -> T.hPutStr handle s
+            WithColor color term -> withSGR [SetColor Foreground Dull color] (go term)
+            WithBold term -> withSGR [SetConsoleIntensity BoldIntensity] (go term)
+
+        withSGR sgrs m
+          | useSGR = hSetSGR handle sgrs >> m >> hSetSGR handle [Reset]
+          | otherwise = m
+
+runTermPure :: Term -> Text
+runTermPure (TermOutput (Const nodes)) =
+  T.concat . toList . flip fmap nodes $ \case
+    OutputText s -> s
+    WithColor _ term -> runTermPure term
+    WithBold term -> runTermPure term
 
 ----------------------------------------------------------------------------
 -- Styling
 
--- | Make the inner computation output bold text.
-bold :: Term a -> Term a
-bold = withSGR [SetConsoleIntensity BoldIntensity]
+-- | Make the output bold text.
+bold :: Term -> Term
+bold = singleTerm . WithBold
 
--- | Make the inner computation output cyan text.
-cyan :: Term a -> Term a
-cyan = withSGR [SetColor Foreground Dull Cyan]
+-- | Make the output cyan text.
+cyan :: Term -> Term
+cyan = singleTerm . WithColor Cyan
 
--- | Make the inner computation output green text.
-green :: Term a -> Term a
-green = withSGR [SetColor Foreground Dull Green]
+-- | Make the output green text.
+green :: Term -> Term
+green = singleTerm . WithColor Green
 
--- | Make the inner computation output red text.
-red :: Term a -> Term a
-red = withSGR [SetColor Foreground Dull Red]
-
--- | Alter 'SGR' for inner computation.
-withSGR :: [SGR] -> Term a -> Term a
-withSGR sgrs (Term m) = Term $ do
-  RC {..} <- ask
-  if rcUseColor
-    then do
-      liftIO $ hSetSGR rcHandle sgrs
-      x <- m
-      liftIO $ hSetSGR rcHandle [Reset]
-      return x
-    else m
+-- | Make the output red text.
+red :: Term -> Term
+red = singleTerm . WithColor Red
 
 ----------------------------------------------------------------------------
 -- Printing
 
 -- | Output 'Text'.
-put :: Text -> Term ()
-put txt = Term $ do
-  RC {..} <- ask
-  liftIO $ T.hPutStr rcHandle txt
+put :: Text -> Term
+put = singleTerm . OutputText
 
--- | Output 'String'.
-putS :: String -> Term ()
-putS str = Term $ do
-  RC {..} <- ask
-  liftIO $ hPutStr rcHandle str
+-- | Output a 'Show' value.
+putShow :: (Show a) => a -> Term
+putShow = put . T.pack . show
 
--- | Output a 'GHC.SrcSpan'.
-putSrcSpan :: SrcSpan -> Term ()
-putSrcSpan = putS . showOutputable
-
--- | Output a 'GHC.RealSrcSpan'.
-putRealSrcSpan :: RealSrcSpan -> Term ()
-putRealSrcSpan = putS . showOutputable
+-- | Output an 'Outputable' value.
+putOutputable :: (Outputable a) => a -> Term
+putOutputable = put . T.pack . showOutputable
 
 -- | Output a newline.
-newline :: Term ()
-newline = Term $ do
-  RC {..} <- ask
-  liftIO $ T.hPutStr rcHandle "\n"
+newline :: Term
+newline = put "\n"

--- a/src/Ormolu/Terminal/QualifiedDo.hs
+++ b/src/Ormolu/Terminal/QualifiedDo.hs
@@ -1,0 +1,7 @@
+module Ormolu.Terminal.QualifiedDo ((>>)) where
+
+import Ormolu.Terminal
+import Prelude hiding ((>>))
+
+(>>) :: Term -> Term -> Term
+(>>) = (<>)

--- a/src/Ormolu/Utils.hs
+++ b/src/Ormolu/Utils.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- | Random utilities used by the code.
 module Ormolu.Utils
@@ -25,13 +23,13 @@ where
 
 import Data.List (dropWhileEnd)
 import Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Foreign as TFFI
+import Data.Text qualified as T
+import Data.Text.Foreign qualified as TFFI
 import Foreign (pokeElemOff, withForeignPtr)
-import qualified GHC.Data.Strict as Strict
+import GHC.Data.Strict qualified as Strict
 import GHC.Data.StringBuffer (StringBuffer (..))
 import GHC.Driver.Ppr
 import GHC.DynFlags (baseDynFlags)
@@ -39,7 +37,7 @@ import GHC.ForeignPtr (mallocPlainForeignPtrBytes)
 import GHC.Hs
 import GHC.IO.Unsafe (unsafePerformIO)
 import GHC.Types.SrcLoc
-import GHC.Utils.Outputable
+import GHC.Utils.Outputable (Outputable (..))
 
 -- | Relative positions in a list.
 data RelativePos

--- a/src/Ormolu/Utils/Cabal.hs
+++ b/src/Ormolu/Utils/Cabal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Ormolu.Utils.Cabal
@@ -15,17 +14,17 @@ where
 
 import Control.Exception
 import Control.Monad.IO.Class
-import qualified Data.ByteString as B
+import Data.ByteString qualified as B
 import Data.IORef
 import Data.Map.Lazy (Map)
-import qualified Data.Map.Lazy as M
+import Data.Map.Lazy qualified as M
 import Data.Maybe (maybeToList)
 import Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Distribution.ModuleName as ModuleName
+import Data.Set qualified as Set
+import Distribution.ModuleName qualified as ModuleName
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parsec
-import qualified Distribution.Types.CondTree as CT
+import Distribution.Types.CondTree qualified as CT
 import Distribution.Utils.Path (getSymbolicPath)
 import Language.Haskell.Extension
 import Ormolu.Config
@@ -141,8 +140,8 @@ parseCabalInfo cabalFileAsGiven sourceFileAsGiven = liftIO $ do
   CachedCabalFile {..} <- whenNothing (M.lookup cabalFile cabalCache) $ do
     cabalFileBs <- B.readFile cabalFile
     genericPackageDescription <-
-      whenNothing (parseGenericPackageDescriptionMaybe cabalFileBs) $
-        throwIO (OrmoluCabalFileParsingFailed cabalFile)
+      whenLeft (snd . runParseResult $ parseGenericPackageDescription cabalFileBs) $
+        throwIO . OrmoluCabalFileParsingFailed cabalFile . snd
     let extensionsAndDeps =
           getExtensionAndDepsMap cabalFile genericPackageDescription
         cachedCabalFile = CachedCabalFile {..}
@@ -163,8 +162,10 @@ parseCabalInfo cabalFileAsGiven sourceFileAsGiven = liftIO $ do
         }
     )
   where
-    whenNothing :: (Monad m) => Maybe a -> m a -> m a
+    whenNothing :: (Applicative f) => Maybe a -> f a -> f a
     whenNothing maya ma = maybe ma pure maya
+    whenLeft :: (Applicative f) => Either e a -> (e -> f a) -> f a
+    whenLeft eitha ma = either ma pure eitha
 
 -- | Get a map from Haskell source file paths (without any extensions) to
 -- the corresponding 'DynOption's and dependencies.

--- a/src/Ormolu/Utils/Fixity.hs
+++ b/src/Ormolu/Utils/Fixity.hs
@@ -11,8 +11,8 @@ import Control.Monad.IO.Class
 import Data.Bifunctor (first)
 import Data.IORef
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
 import Ormolu.Exception
 import Ormolu.Fixity
 import Ormolu.Fixity.Parser

--- a/src/Ormolu/Utils/IO.hs
+++ b/src/Ormolu/Utils/IO.hs
@@ -10,9 +10,9 @@ where
 import Control.Exception (throwIO)
 import Control.Monad.IO.Class
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as B
+import Data.ByteString qualified as B
 import Data.Text (Text)
-import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding qualified as TE
 
 -- | Write a 'Text' to a file using UTF8 and ignoring native
 -- line ending conventions.

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -1,9 +1,0 @@
-resolver: lts-19.20
-
-extra-deps:
-  - Cabal-syntax-3.8.1.0
-  - ghc-lib-parser-9.4.1.20220807
-  - text-2.0.1
-  - parsec-3.1.16.1
-  - hashable-1.4.2.0
-  - data-array-byte-0.1.0.1

--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -1,8 +1,8 @@
-resolver: lts-20.0
+resolver: lts-20.17
 
 extra-deps:
-  - Cabal-syntax-3.8.1.0
-  - ghc-lib-parser-9.4.1.20220807
+  - Cabal-syntax-3.10.1.0
+  - ghc-lib-parser-9.6.1.20230312
   - text-2.0.1
   - parsec-3.1.16.1
   - hashable-1.4.2.0

--- a/stack-ghc-9.6.yaml
+++ b/stack-ghc-9.6.yaml
@@ -1,5 +1,8 @@
 resolver: nightly-2023-04-03
+compiler: ghc-9.6.1
 
 extra-deps:
   - Cabal-syntax-3.10.1.0
   - ghc-lib-parser-9.6.1.20230312
+  - unix-compat-0.7
+  - happy-1.20.1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-ghc-9.0.yaml
+stack-ghc-9.2.yaml

--- a/tests/Ormolu/CabalInfoSpec.hs
+++ b/tests/Ormolu/CabalInfoSpec.hs
@@ -2,7 +2,7 @@
 
 module Ormolu.CabalInfoSpec (spec) where
 
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Distribution.Types.PackageName (unPackageName)
 import Ormolu.Config (DynOption (..))
 import Ormolu.Utils.Cabal
@@ -35,15 +35,15 @@ spec = do
       (mentioned, CabalInfo {..}) <- parseCabalInfo "fourmolu.cabal" "src/Ormolu/Config.hs"
       mentioned `shouldBe` True
       unPackageName ciPackageName `shouldBe` "fourmolu"
-      ciDynOpts `shouldBe` [DynOption "-XHaskell2010"]
-      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "binary", "bytestring", "containers", "directory", "dlist", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "scientific", "syb", "text", "yaml"]
+      ciDynOpts `shouldBe` [DynOption "-XGHC2021"]
+      Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "MemoTrie", "aeson", "ansi-terminal", "array", "base", "binary", "bytestring", "containers", "deepseq", "directory", "file-embed", "filepath", "ghc-lib-parser", "megaparsec", "mtl", "scientific", "syb", "text", "yaml"]
       ciCabalFilePath `shouldSatisfy` isAbsolute
       makeRelativeToCurrentDirectory ciCabalFilePath `shouldReturn` "fourmolu.cabal"
     it "extracts correct cabal info from fourmolu.cabal for tests/Ormolu/PrinterSpec.hs" $ do
       (mentioned, CabalInfo {..}) <- parseCabalInfo "fourmolu.cabal" "tests/Ormolu/PrinterSpec.hs"
       mentioned `shouldBe` True
       unPackageName ciPackageName `shouldBe` "fourmolu"
-      ciDynOpts `shouldBe` [DynOption "-XHaskell2010"]
+      ciDynOpts `shouldBe` [DynOption "-XGHC2021"]
       Set.map unPackageName ciDependencies `shouldBe` Set.fromList ["Cabal-syntax", "Diff", "QuickCheck", "base", "containers", "directory", "filepath", "ghc-lib-parser", "hspec", "hspec-megaparsec", "fourmolu", "path", "path-io", "pretty", "process", "temporary", "text"]
       ciCabalFilePath `shouldSatisfy` isAbsolute
       makeRelativeToCurrentDirectory ciCabalFilePath `shouldReturn` "fourmolu.cabal"

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -14,10 +14,10 @@ import Control.Exception (catch)
 import Control.Monad (forM_, when)
 import Data.Algorithm.DiffContext (getContextDiff, prettyContextDiff)
 import Data.Char (isSpace)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (isJust)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import GHC.Stack (withFrozenCallStack)
 import Ormolu
   ( Config (..),
@@ -48,7 +48,7 @@ import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Hspec
-import qualified Text.PrettyPrint as Doc
+import Text.PrettyPrint qualified as Doc
 import Text.Printf (printf)
 
 data TestGroup = forall a.

--- a/tests/Ormolu/Diff/TextSpec.hs
+++ b/tests/Ormolu/Diff/TextSpec.hs
@@ -2,14 +2,11 @@
 
 module Ormolu.Diff.TextSpec (spec) where
 
-import Data.Text (Text)
 import Ormolu.Diff.Text
 import Ormolu.Terminal
 import Ormolu.Utils.IO
 import Path
-import Path.IO
-import qualified System.FilePath as FP
-import System.IO (hClose)
+import System.FilePath qualified as FP
 import Test.Hspec
 
 spec :: Spec
@@ -48,16 +45,7 @@ stdTest name pathA pathB = it name $ do
     parseRelFile expectedDiffPath
       >>= readFileUtf8 . toFilePath . (diffOutputsDir </>)
   Just actualDiff <- pure $ diffText inputA inputB "TEST"
-  actualDiffText <- printDiff actualDiff
-  actualDiffText `shouldBe` expectedDiffText
-
--- | Print to a 'Text' value.
-printDiff :: TextDiff -> IO Text
-printDiff diff =
-  withSystemTempFile "ormolu-diff-test" $ \path h -> do
-    runTerm (printTextDiff diff) Never h
-    hClose h
-    readFileUtf8 (toFilePath path)
+  runTermPure (printTextDiff actualDiff) `shouldBe` expectedDiffText
 
 diffTestsDir :: Path Rel Dir
 diffTestsDir = $(mkRelDir "data/diff-tests")

--- a/tests/Ormolu/Fixity/ParserSpec.hs
+++ b/tests/Ormolu/Fixity/ParserSpec.hs
@@ -2,9 +2,9 @@
 
 module Ormolu.Fixity.ParserSpec (spec) where
 
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Ormolu.Fixity
 import Ormolu.Fixity.Parser
 import Test.Hspec

--- a/tests/Ormolu/Fixity/PrinterSpec.hs
+++ b/tests/Ormolu/Fixity/PrinterSpec.hs
@@ -2,9 +2,9 @@
 
 module Ormolu.Fixity.PrinterSpec (spec) where
 
-import qualified Data.Char as Char
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
+import Data.Char qualified as Char
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
 import Ormolu.Fixity
 import Ormolu.Fixity.Parser
 import Ormolu.Fixity.Printer

--- a/tests/Ormolu/HackageInfoSpec.hs
+++ b/tests/Ormolu/HackageInfoSpec.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 
 module Ormolu.HackageInfoSpec (spec) where
 
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Distribution.Types.PackageName (PackageName)
 import Ormolu.Fixity
 import Test.Hspec

--- a/tests/Ormolu/OpTreeSpec.hs
+++ b/tests/Ormolu/OpTreeSpec.hs
@@ -2,10 +2,10 @@
 
 module Ormolu.OpTreeSpec (spec) where
 
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import GHC.Types.Name (mkOccName, varName)
 import GHC.Types.Name.Reader (mkRdrUnqual)
 import Ormolu.Fixity

--- a/tests/Ormolu/Parser/OptionsSpec.hs
+++ b/tests/Ormolu/Parser/OptionsSpec.hs
@@ -3,7 +3,7 @@
 
 module Ormolu.Parser.OptionsSpec (spec) where
 
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Ormolu
 import Test.Hspec
 

--- a/tests/Ormolu/Parser/PragmaSpec.hs
+++ b/tests/Ormolu/Parser/PragmaSpec.hs
@@ -3,7 +3,7 @@
 module Ormolu.Parser.PragmaSpec (spec) where
 
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Ormolu.Parser.Pragma
 import Test.Hspec
 

--- a/tests/Ormolu/PrinterSpec.hs
+++ b/tests/Ormolu/PrinterSpec.hs
@@ -7,11 +7,11 @@ module Ormolu.PrinterSpec (spec) where
 import Control.Exception
 import Control.Monad
 import Data.List (isSuffixOf)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Maybe (isJust)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
 import Ormolu
 import Ormolu.Config
 import Ormolu.Fixity
@@ -19,7 +19,7 @@ import Ormolu.Utils.IO
 import Path
 import Path.IO
 import System.Environment (lookupEnv)
-import qualified System.FilePath as F
+import System.FilePath qualified as F
 import Test.Hspec
 
 spec :: Spec


### PR DESCRIPTION
Big thing in this update is GHC 9.6 support.

One notable update is Ormolu stopped generating any caret haddocks (https://github.com/tweag/ormolu/pull/993), whereas we still want caret haddocks when generating function types with leading arrows. So what I did is (temporarily) remove the pipe/caret distinction in `p_hsType`, then readded it.

Will release 0.12 after this merges