### PR TITLE
Fix fourmolu demo for new ormolu

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -13,27 +13,29 @@ This directory contains files that are served at `fourmolu.github.io`.
 
 ### Build locally
 
-To build locally, follow the steps at https://gitlab.haskell.org/ghc/ghc-wasm-meta to install GHC with the WASM backend. Then run the following steps:
+1. Follow the steps at https://gitlab.haskell.org/ghc/ghc-wasm-meta to install GHC with the WASM backend
 
-```bash
-wasm32-wasi-cabal update
-web/fourmolu-wasm/build.sh
-```
+1. `wasm32-wasi-cabal update`
+
+1. `web/fourmolu-wasm/build.sh`
 
 ### Build with Docker
 
-If it's too difficult to install GHC with WASM locally, you can run the WASM build in a Docker container:
+If it's too difficult to install locally, you can run the WASM build in a Docker container:
 
 ```bash
-# host machine
+# in the root directory of the fourmolu repo
+docker build -t fourmolu-wasm -f web/fourmolu-wasm/Dockerfile .
 docker run --rm -it \
     -v $PWD:/src \
     -v /tmp/fourmolu-wasm-cabal-cache:/root/.wasm32-wasi-cabal \
     -e CABAL_DIR=/root/.wasm32-wasi-cabal \
     --entrypoint bash \
-    brandonchinn178/ghc-wasm-backend
+    fourmolu-wasm
+```
 
-# in docker
+```bash
+# in the Docker container
 wasm32-wasi-cabal update
 /src/web/fourmolu-wasm/build.sh
 ```

--- a/web/README.md
+++ b/web/README.md
@@ -15,6 +15,8 @@ This directory contains files that are served at `fourmolu.github.io`.
 
 1. Follow the steps at https://gitlab.haskell.org/ghc/ghc-wasm-meta to install GHC with the WASM backend
 
+1. Install [Wizer](https://github.com/bytecodealliance/wizer)
+
 1. `wasm32-wasi-cabal update`
 
 1. `web/fourmolu-wasm/build.sh`

--- a/web/fourmolu-wasm/Dockerfile
+++ b/web/fourmolu-wasm/Dockerfile
@@ -1,1 +1,5 @@
 FROM brandonchinn178/ghc-wasm-backend
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install wizer --version=1.6.0 --all-features

--- a/web/fourmolu-wasm/Dockerfile
+++ b/web/fourmolu-wasm/Dockerfile
@@ -1,0 +1,1 @@
+FROM brandonchinn178/ghc-wasm-backend

--- a/web/fourmolu-wasm/build.sh
+++ b/web/fourmolu-wasm/build.sh
@@ -19,8 +19,16 @@ listbin() {
 # can't do cabal install because it'll build fourmolu too
 # https://github.com/haskell/cabal/issues/8614
 wasm32-wasi-cabal build exe:fourmolu-wasm "${ARGS[@]}"
+
 mkdir -p "${HERE}/dist/"
-cp "$(listbin fourmolu-wasm)" "${HERE}/dist/"
+
+# pre-initialize wasm
+wizer \
+    --allow-wasi --wasm-bulk-memory true \
+    "$(listbin fourmolu-wasm)" -o "${HERE}/dist/fourmolu-wasm.wasm" \
+    --mapdir /::../../extract-hackage-info
+
+# TODO: use wasm-opt to optimize wasm binary for code size
 
 # symlink WASM output, for development
 ln -sf ../../fourmolu-wasm/dist/fourmolu-wasm.wasm ../site/static/

--- a/web/fourmolu-wasm/cbits/init.c
+++ b/web/fourmolu-wasm/cbits/init.c
@@ -1,0 +1,19 @@
+#include <Rts.h>
+#include "Main_stub.h"
+
+__attribute__((export_name("wizer.initialize"))) void __wizer_initialize(void) {
+  char *args[] = {
+    "fourmolu-wasm.wasm",
+    "+RTS",
+    "--nonmoving-gc",
+    "-H64m",
+    "-RTS",
+  };
+  int argc = sizeof(args) / sizeof(args[0]);
+  char **argv = args;
+  hs_init_with_rtsopts(&argc, &argv);
+  evaluateFixityInfo();
+  hs_perform_gc();
+  hs_perform_gc();
+  rts_clearMemory();
+}

--- a/web/fourmolu-wasm/fourmolu-wasm.cabal
+++ b/web/fourmolu-wasm/fourmolu-wasm.cabal
@@ -8,6 +8,7 @@ executable fourmolu-wasm
     hs-source-dirs: src
     other-modules:
         ForeignUtils
+    c-sources: cbits/init.c
     default-language: GHC2021
     ghc-options:
         -Wall
@@ -15,11 +16,9 @@ executable fourmolu-wasm
         -no-hs-main
         -optl-mexec-model=reactor
         "-optl-Wl\
-        \,--export=hs_init\
         \,--export=malloc\
         \,--export=free\
         \,--export=runFourmolu\
-        \,--export=initFixityDB\
         \,--export=getString\
         \,--export=getStringLen\
         \,--export=freeStringWithLen\
@@ -29,6 +28,7 @@ executable fourmolu-wasm
         , aeson
         , base
         , bytestring
+        , deepseq
         , fourmolu
         , ghc-lib-parser
         , ghc-syntax-highlighter-themed

--- a/web/site/static/hackage-info.bin
+++ b/web/site/static/hackage-info.bin
@@ -1,1 +1,0 @@
-../../../extract-hackage-info/hackage-info.bin

--- a/web/worker/index.js
+++ b/web/worker/index.js
@@ -4,10 +4,7 @@ const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 
 async function main() {
-  const [wasm, hackageInfoBuf] = await Promise.all([
-    initWebAssembly(fetch('/static/fourmolu-wasm.wasm')),
-    fetch('/static/hackage-info.bin').then((r) => r.arrayBuffer()),
-  ])
+  const wasm = await initWebAssembly(fetch('/static/fourmolu-wasm.wasm'))
   const hs = wasm.instance.exports
 
   const withBytesPtr = (bytes, callback) => {
@@ -20,11 +17,6 @@ async function main() {
       hs.free(ptr)
     }
   }
-
-  hs._initialize()
-  hs.hs_init(0, 0)
-
-  withBytesPtr(hackageInfoBuf, hs.initFixityDB)
 
   self.onmessage = (event) => {
     const inputBytes = encoder.encode(event.data)


### PR DESCRIPTION
The new ormolu merge [changed](https://github.com/tweag/ormolu/pull/991) how the fixity database is loaded (preinitialized with wizer instead of fetched at runtime). If you use any infix operators at fourmolu.github.io, it'll show an error.

@georgefst I can't compile this right now because `rts_clearMemory` was added [2 months ago](https://gitlab.haskell.org/ghc/ghc/-/commit/9ca51f9e84abc41ba590203d8bc8df8d6af86db2) while my build of GHC wasm is too old, and I'm getting a weird error about `tzset` being undeclared when rebuilding GHC. I'll try to get it working on my end, but if you can get it working, feel free to test/fix/merge.