### PR TITLE
Relax upper bound to accommodate ansi-terminal-1.0

### DIFF
--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -107,7 +107,7 @@ library
         Cabal-syntax >=3.10 && <3.11,
         Diff >=0.4 && <1.0,
         MemoTrie >=0.6 && <0.7,
-        ansi-terminal >=0.10 && <1.0,
+        ansi-terminal >=0.10 && <1.1,
         array >=0.5 && <0.6,
         base >=4.14 && <5.0,
         binary >=0.8 && <0.9,


### PR DESCRIPTION
`ansi-terminal-1.0` is released on Hackage.

See also https://github.com/commercialhaskell/stackage/issues/6976.

Tested by building with Stack >= 2.9.3 and `stack-ghc-9.2.yaml` with additions:
~~~yaml
extra-deps:
  - ansi-terminal-1.0
  - ansi-terminal-types-0.11.5

allow-newer: true
allow-newer-deps:
- ansi-wl-pprint
~~~