### PR TITLE
Consolidate integration tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ repos:
         files: '\.(hs|hs-boot)$'
         exclude: |
           (?x)^(
-            region-tests/(?!Main.hs)
-            | fixity-tests/(?!Main.hs)
+            region-tests/
+            | fixity-tests/
             | data/examples/
             | data/fourmolu/
             | data/diff-tests/

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -162,7 +162,7 @@ Fourmolu aims to continue merging upstream changes in Ormolu. Whenever Ormolu ma
     * `expected-failures/`
 
 * If any of the `default.nix` files are changed, manually verify that all end-to-end tests are accounted for. After doing so, `git rm` each of them.
-    * For example, `./region-tests/` is one directory of tests, which is captured in the `fourmolu:region-tests` test suite, where every test in `region-tests/default.nix` has been ported into the Haskell test suite.
+    * For example, `./region-tests/` is one directory of tests, which is captured in the `Ormolu.Integration.RegionSpec` test suite, where every test in `region-tests/default.nix` has been ported into the Haskell test suite.
 
 * Any Ormolu additions to `CHANGELOG.md` should NOT be kept, but instead be added to a new file in `changelog.d/` (e.g. named `ormolu-X.Y.Z`). See `changelog.d/README.md` for more details.
 

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -213,8 +213,8 @@ test-suite tests
 
     -- specific to fourmolu tests
     other-modules:
-        Ormolu.Config.OptionsSpec
         Ormolu.Config.PrinterOptsSpec
+        Ormolu.Integration.CLIOptionsSpec
     build-depends:
         Diff >=0.3 && <0.5,
         pretty >=1.0 && <2.0,

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -215,6 +215,8 @@ test-suite tests
     other-modules:
         Ormolu.Config.PrinterOptsSpec
         Ormolu.Integration.CLIOptionsSpec
+        Ormolu.Integration.FixitySpec
+        Ormolu.Integration.RegionSpec
     build-depends:
         Diff >=0.3 && <0.5,
         pretty >=1.0 && <2.0,
@@ -225,37 +227,5 @@ test-suite tests
             -Wall -Werror -Wredundant-constraints -Wpartial-fields
             -Wunused-packages
 
-    else
-        ghc-options: -O2 -Wall
-
-test-suite region-tests
-    import: integration-test-utils
-    type:               exitcode-stdio-1.0
-    main-is:            Main.hs
-    hs-source-dirs:     region-tests
-    default-language:   Haskell2010
-    build-depends:
-        base >=4.14 && <5.0,
-        hspec >=2.0 && <3.0,
-        temporary >=1.3 && <1.4
-
-    if flag(dev)
-        ghc-options: -Wall -Werror
-    else
-        ghc-options: -O2 -Wall
-
-test-suite fixity-tests
-    import: integration-test-utils
-    type:               exitcode-stdio-1.0
-    main-is:            Main.hs
-    hs-source-dirs:     fixity-tests
-    default-language:   Haskell2010
-    build-depends:
-        base >=4.14 && <5.0,
-        hspec >=2.0 && <3.0,
-        temporary >=1.3 && <1.4
-
-    if flag(dev)
-        ghc-options: -Wall -Werror
     else
         ghc-options: -O2 -Wall

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -168,16 +168,7 @@ executable fourmolu
     else
         ghc-options: -O2 -Wall -rtsopts
 
-common integration-test-utils
-    build-tool-depends: fourmolu:fourmolu
-    hs-source-dirs: tests/utils/
-    other-modules: IntegrationUtils
-    build-depends:
-        directory >=1.3 && <1.4,
-        process >=1.6 && <2.0
-
 test-suite tests
-    import: integration-test-utils
     type:               exitcode-stdio-1.0
     main-is:            Spec.hs
     build-tool-depends: hspec-discover:hspec-discover >=2.0 && <3.0
@@ -217,10 +208,13 @@ test-suite tests
         Ormolu.Integration.CLIOptionsSpec
         Ormolu.Integration.FixitySpec
         Ormolu.Integration.RegionSpec
+        Ormolu.Integration.Utils
     build-depends:
         Diff >=0.3 && <0.5,
         pretty >=1.0 && <2.0,
+        process >=1.6 && <2.0,
         fourmolu
+    build-tool-depends: fourmolu:fourmolu
 
     if flag(dev)
         ghc-options:

--- a/hie.yaml
+++ b/hie.yaml
@@ -18,12 +18,6 @@ cradle:
             - path: "tests"
               component: "fourmolu:test:tests"
 
-            - path: "region-tests"
-              component: "fourmolu:test:region-tests"
-
-            - path: "fixity-tests"
-              component: "fourmolu:test:fixity-tests"
-
     - path: "config"
       config:
         cradle:

--- a/tests/Ormolu/Integration/CLIOptionsSpec.hs
+++ b/tests/Ormolu/Integration/CLIOptionsSpec.hs
@@ -1,4 +1,4 @@
-module Ormolu.Config.OptionsSpec (spec) where
+module Ormolu.Integration.CLIOptionsSpec (spec) where
 
 import Data.List (isPrefixOf)
 import IntegrationUtils (getFourmoluExe, readProcess)

--- a/tests/Ormolu/Integration/CLIOptionsSpec.hs
+++ b/tests/Ormolu/Integration/CLIOptionsSpec.hs
@@ -1,7 +1,7 @@
 module Ormolu.Integration.CLIOptionsSpec (spec) where
 
 import Data.List (isPrefixOf)
-import IntegrationUtils (getFourmoluExe, readProcess)
+import Ormolu.Integration.Utils (getFourmoluExe, readProcess)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec

--- a/tests/Ormolu/Integration/FixitySpec.hs
+++ b/tests/Ormolu/Integration/FixitySpec.hs
@@ -5,7 +5,7 @@
 module Ormolu.Integration.FixitySpec (spec) where
 
 import Control.Monad (forM_)
-import IntegrationUtils (getFourmoluExe, readProcess)
+import Ormolu.Integration.Utils (getFourmoluExe, readProcess)
 import System.Directory (copyFile)
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec

--- a/tests/Ormolu/Integration/FixitySpec.hs
+++ b/tests/Ormolu/Integration/FixitySpec.hs
@@ -2,14 +2,18 @@
 
 {-# LANGUAGE RecordWildCards #-}
 
+module Ormolu.Integration.FixitySpec (spec) where
+
 import Control.Monad (forM_)
 import IntegrationUtils (getFourmoluExe, readProcess)
 import System.Directory (copyFile)
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
-main :: IO ()
-main = hspec $
+-- | Tests for the `fixity-tests/` directory Ormolu implemented, converted
+-- from nix tests to hspec tests.
+spec :: Spec
+spec =
   describe "fixity-tests" . beforeAll getFourmoluExe $
     forM_ tests $ \Test {..} ->
       specify testLabel $ \fourmoluExe ->

--- a/tests/Ormolu/Integration/RegionSpec.hs
+++ b/tests/Ormolu/Integration/RegionSpec.hs
@@ -3,7 +3,7 @@
 module Ormolu.Integration.RegionSpec (spec) where
 
 import Control.Monad (forM_)
-import IntegrationUtils (getFourmoluExe, readProcess)
+import Ormolu.Integration.Utils (getFourmoluExe, readProcess)
 import System.Directory (copyFile)
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec

--- a/tests/Ormolu/Integration/RegionSpec.hs
+++ b/tests/Ormolu/Integration/RegionSpec.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE RecordWildCards #-}
 
+module Ormolu.Integration.RegionSpec (spec) where
+
 import Control.Monad (forM_)
 import IntegrationUtils (getFourmoluExe, readProcess)
 import System.Directory (copyFile)
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
-main :: IO ()
-main = hspec $
+-- | Tests for the `region-tests/` directory Ormolu implemented, converted
+-- from nix tests to hspec tests.
+spec :: Spec
+spec =
   describe "region-tests" . beforeAll getFourmoluExe $
     forM_ tests $ \Test {..} ->
       specify testLabel $ \fourmoluExe -> do

--- a/tests/Ormolu/Integration/Utils.hs
+++ b/tests/Ormolu/Integration/Utils.hs
@@ -1,4 +1,4 @@
-module IntegrationUtils
+module Ormolu.Integration.Utils
   ( getFourmoluExe,
     readProcess,
   )


### PR DESCRIPTION
There's no reason to implement `fixity-tests` and `region-tests` in separate test suites, so I consolidated all the integration tests into `tests/Ormolu/Integration/`