### PR TITLE
Bump deepseq bounds

### DIFF
--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -114,7 +114,7 @@ library
         binary >=0.8 && <0.9,
         bytestring >=0.2 && <0.12,
         containers >=0.5 && <0.7,
-        deepseq >=1.4 && <1.5,
+        deepseq >=1.4 && <1.6,
         directory ^>=1.3,
         file-embed >=0.0.15 && <0.1,
         filepath >=1.2 && <1.5,


### PR DESCRIPTION
Tested with
```bash
cabal test --constraint='deepseq==1.5.0.0' --allow-newer=deepseq --allow-boot-library-installs
```

Already pushed a revision to Hackage for 0.13.1.0