### PR TITLE
Fix column-limit with BlockArguments

### DIFF
--- a/changelog.d/column-limit-block-args.md
+++ b/changelog.d/column-limit-block-args.md
@@ -1,0 +1,1 @@
+* Fix `column-limit` with `BlockArguments` ([#377](https://github.com/fourmolu/fourmolu/issues/377))

--- a/data/fourmolu/column-limit/input-multi.hs
+++ b/data/fourmolu/column-limit/input-multi.hs
@@ -73,3 +73,19 @@ testFund =
         abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde
         $ do
             result <- aRandomResult
+
+{- // -}
+
+{----- BlockArguments (https://github.com/fourmolu/fourmolu/issues/377) -----}
+
+
+{-# LANGUAGE BlockArguments #-}
+
+putThen :: String -> IO a -> IO a
+putThen s action =
+    putStrLn s >> action
+
+main :: IO ()
+main = do
+    putThen "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789" do
+        putStrLn ""

--- a/data/fourmolu/column-limit/input.hs
+++ b/data/fourmolu/column-limit/input.hs
@@ -1,10 +1,8 @@
-module ColumnLimitTest where
-
 -- Less than 80 characters
-import Data.List (isPrefixOf, head, tail)
+import Data.List (head, isPrefixOf, tail)
 
 -- Over 80 characters, should break this line when column-limit is set to 80.
-import Data.Maybe (maybe, fromMaybe, fromJust, catMaybe, mapMaybe, isJust, isNothing, listToMaybe, maybeToList)
+import Data.Maybe (catMaybe, fromJust, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybe, maybeToList)
 
 -- For reference, this line had exactly 80 characters -------------------------|
 
@@ -14,52 +12,48 @@ oneVeryLongLine = ["akjsndjklansdsad"] ++ ["jkanskdjnajsndjnasd"] ++ ["jknasdljk
 oneVeryLongList :: [String]
 oneVeryLongList = ["akjsndjklansdsad", "jkanskdjnajsndjnasd", "jknasdljknasdlnasdn", "lajndljnasdlnasds"]
 
-
 data NewDataType = NewDataType {field1 :: String, field2 :: String, field3 :: String, field4 :: String}
 
 -- Test if the current line breaking still works normally, i.e. if the user
--- breaks the line, fourmolu breaks and aligns the rest.    
+-- breaks the line, fourmolu breaks and aligns the rest.
 data SecondDataType = SecondDataType {field1 :: String
     , field2 :: String, field3 :: String, field4 :: String}
 
 data DataTypeWithAVeryLongName = DataTypeWithAVeryLongName String String String String String
 
-
--- Long function signatures
-
 -- For reference, this line had exactly 80 characters -------------------------|
+
+{----- Long function signatures -----}
 
 longFunction0 :: String -> String -> String -> Maybe Int -> Maybe Int -> Maybe Int -> String -> [String]
 longFunction0 veryLongArg1 a b c d e f = ["a list", "of strings", "that will break the", "column limit"]
 
 longFunction1 :: String -> String -> String -> Maybe Int -> Maybe Int -> Maybe Int -> String
-longFunction1 
+longFunction1
     veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 veryLongArgument5 veryLongArg6 = undefined
 
-longFunction12 veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 veryLongArgument5 
+longFunction12 veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 veryLongArgument5
 longFunction12 :: String -> String -> String -> Maybe Int -> Maybe Int -> Maybe Int -> String -> String
     veryLongArg6 veryLongArg6 = undefined
-
 
 longFunction2 :: String -> String -> String -> Maybe Int -> Maybe Int -> Maybe Int -> String
 longFunction2 veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 a veryLongArg6 =
     let aVeryLongLine = ["list one", "list one", "list one", "list one", "list one", "list one"]
-    in undefined
+     in undefined
 
 longFunction3 :: String -> String -> String -> Maybe Int -> Maybe Int -> Maybe Int -> String
 longFunction3 veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 veryLongArgument5 veryLongArg6 = undefined
 
-
 -- For reference, this line had exactly 80 characters -------------------------|
 
--- ----------------  Known limitation: idempotence is broken ----------------
+{-----  Known limitation: idempotence is broken -----}
 
 -- With the column-limit option set, fourmolu will not be idempotent in some
 -- cases. An example can be seen below, where the long line ends with a `do`.
 
 -- Original code
 testFund :: Maybe Int
-testFund = 
+testFund =
   firstTest oneFunctionArgument abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde $ do
     result <- aRandomResult
 
@@ -70,7 +64,6 @@ testFund =
         oneFunctionArgument
         abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde $ do
         result <- aRandomResult
-
 
 -- Which, if formatted again, will become this:
 testFund :: Maybe Int

--- a/data/fourmolu/column-limit/output-limit=100.hs
+++ b/data/fourmolu/column-limit/output-limit=100.hs
@@ -1,5 +1,3 @@
-module ColumnLimitTest where
-
 -- Less than 80 characters
 import Data.List (head, isPrefixOf, tail)
 
@@ -38,9 +36,9 @@ data SecondDataType = SecondDataType
 
 data DataTypeWithAVeryLongName = DataTypeWithAVeryLongName String String String String String
 
--- Long function signatures
-
 -- For reference, this line had exactly 80 characters -------------------------|
+
+{----- Long function signatures -----}
 
 longFunction0 ::
     String -> String -> String -> Maybe Int -> Maybe Int -> Maybe Int -> String -> [String]
@@ -78,7 +76,7 @@ longFunction3 veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 veryLongArgume
 
 -- For reference, this line had exactly 80 characters -------------------------|
 
--- ----------------  Known limitation: idempotence is broken ----------------
+{-----  Known limitation: idempotence is broken -----}
 
 -- With the column-limit option set, fourmolu will not be idempotent in some
 -- cases. An example can be seen below, where the long line ends with a `do`.

--- a/data/fourmolu/column-limit/output-limit=100.hs
+++ b/data/fourmolu/column-limit/output-limit=100.hs
@@ -104,3 +104,19 @@ testFund =
         abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde
         $ do
             result <- aRandomResult
+
+{- // -}
+
+{----- BlockArguments (https://github.com/fourmolu/fourmolu/issues/377) -----}
+{-# LANGUAGE BlockArguments #-}
+
+putThen :: String -> IO a -> IO a
+putThen s action =
+    putStrLn s >> action
+
+main :: IO ()
+main = do
+    putThen
+        "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+        do
+            putStrLn ""

--- a/data/fourmolu/column-limit/output-limit=80.hs
+++ b/data/fourmolu/column-limit/output-limit=80.hs
@@ -1,5 +1,3 @@
-module ColumnLimitTest where
-
 -- Less than 80 characters
 import Data.List (head, isPrefixOf, tail)
 
@@ -48,9 +46,9 @@ data SecondDataType = SecondDataType
 data DataTypeWithAVeryLongName
     = DataTypeWithAVeryLongName String String String String String
 
--- Long function signatures
-
 -- For reference, this line had exactly 80 characters -------------------------|
+
+{----- Long function signatures -----}
 
 longFunction0 ::
     String ->
@@ -103,7 +101,7 @@ longFunction3 veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 veryLongArgume
 
 -- For reference, this line had exactly 80 characters -------------------------|
 
--- ----------------  Known limitation: idempotence is broken ----------------
+{-----  Known limitation: idempotence is broken -----}
 
 -- With the column-limit option set, fourmolu will not be idempotent in some
 -- cases. An example can be seen below, where the long line ends with a `do`.

--- a/data/fourmolu/column-limit/output-limit=80.hs
+++ b/data/fourmolu/column-limit/output-limit=80.hs
@@ -131,3 +131,19 @@ testFund =
         abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde
         $ do
             result <- aRandomResult
+
+{- // -}
+
+{----- BlockArguments (https://github.com/fourmolu/fourmolu/issues/377) -----}
+{-# LANGUAGE BlockArguments #-}
+
+putThen :: String -> IO a -> IO a
+putThen s action =
+    putStrLn s >> action
+
+main :: IO ()
+main = do
+    putThen
+        "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+        do
+            putStrLn ""

--- a/data/fourmolu/column-limit/output-limit=none.hs
+++ b/data/fourmolu/column-limit/output-limit=none.hs
@@ -92,3 +92,17 @@ testFund =
         abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde
         $ do
             result <- aRandomResult
+
+{- // -}
+
+{----- BlockArguments (https://github.com/fourmolu/fourmolu/issues/377) -----}
+{-# LANGUAGE BlockArguments #-}
+
+putThen :: String -> IO a -> IO a
+putThen s action =
+    putStrLn s >> action
+
+main :: IO ()
+main = do
+    putThen "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789" do
+        putStrLn ""

--- a/data/fourmolu/column-limit/output-limit=none.hs
+++ b/data/fourmolu/column-limit/output-limit=none.hs
@@ -1,5 +1,3 @@
-module ColumnLimitTest where
-
 -- Less than 80 characters
 import Data.List (head, isPrefixOf, tail)
 
@@ -27,9 +25,9 @@ data SecondDataType = SecondDataType
 
 data DataTypeWithAVeryLongName = DataTypeWithAVeryLongName String String String String String
 
--- Long function signatures
-
 -- For reference, this line had exactly 80 characters -------------------------|
+
+{----- Long function signatures -----}
 
 longFunction0 :: String -> String -> String -> Maybe Int -> Maybe Int -> Maybe Int -> String -> [String]
 longFunction0 veryLongArg1 a b c d e f = ["a list", "of strings", "that will break the", "column limit"]
@@ -66,7 +64,7 @@ longFunction3 veryLongArg1 veryLongArg2 veryLongArg3 veryLongArg4 veryLongArgume
 
 -- For reference, this line had exactly 80 characters -------------------------|
 
--- ----------------  Known limitation: idempotence is broken ----------------
+{-----  Known limitation: idempotence is broken -----}
 
 -- With the column-limit option set, fourmolu will not be idempotent in some
 -- cases. An example can be seen below, where the long line ends with a `do`.

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -644,12 +644,11 @@ p_hsExpr' isApp s = \case
         initSpan =
           combineSrcSpans' $
             getLocA f :| [(srcLocSpan . srcSpanStart . getLocA) lastp]
-        -- Hang the last argument only if the initial arguments span one
-        -- line.
-        placement =
-          if isOneLineSpan initSpan
-            then exprPlacement (unLoc lastp)
-            else Normal
+    -- Hang the last argument only if the initial arguments span one line.
+    placement <-
+      spansLayout [initSpan] <&> \case
+        SingleLine -> exprPlacement (unLoc lastp)
+        MultiLine -> Normal
     -- If the last argument is not hanging, just separate every argument as
     -- usual. If it is hanging, print the initial arguments and hang the
     -- last one. Also, use braces around the every argument except the last

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -86,7 +86,7 @@ spec =
         },
       TestGroup
         { label = "column-limit",
-          isMulti = False,
+          isMulti = True,
           testCases = [NoLimit, ColumnLimit 80, ColumnLimit 100],
           updateConfig = \columnLimit opts -> opts {poColumnLimit = pure columnLimit},
           showTestCase = show,


### PR DESCRIPTION
Fixed #377 

There are also other similar places, e.g.
* https://github.com/fourmolu/fourmolu/blob/7a2d6dde1a9bb77ec3efc1a20c6199c194386a5d/src/Ormolu/Printer/Meat/Declaration/Value.hs#L322-L324
* https://github.com/fourmolu/fourmolu/blob/7a2d6dde1a9bb77ec3efc1a20c6199c194386a5d/src/Ormolu/Printer/Meat/Declaration/Value.hs#L432-L434
* https://github.com/fourmolu/fourmolu/blob/7a2d6dde1a9bb77ec3efc1a20c6199c194386a5d/src/Ormolu/Printer/Meat/Declaration/Value.hs#L587-L590

But I'm not sure how to fix this more generally. Leaving those unfixed for now