### PR TITLE
Fix first module re-export with section heading

### DIFF
--- a/.github/workflows/format-compat.yml
+++ b/.github/workflows/format-compat.yml
@@ -18,12 +18,12 @@ jobs:
             repo: haskell/cabal
             # TODO: pin this to the next released version of Cabal that uses fourmolu
             ref: 439d68efb74bd8f1c2215301d214d9459acdfa63
-            cmd: fourmolu -m check Cabal Cabal-syntax cabal-install
+            args: Cabal Cabal-syntax cabal-install
           -
             name: swarm
             repo: swarm-game/swarm
             ref: 0.4.0.0
-            cmd: fourmolu -m check src app test
+            args: src app test
 
     name: 'format_compat: ${{ matrix.name }}'
     runs-on: ubuntu-latest
@@ -56,7 +56,11 @@ jobs:
         working-directory: target
         run: |
           git apply --allow-empty ../fourmolu/compat-tests/${{ matrix.name }}.diff
-          ${{ matrix.cmd }}
+          fourmolu -i ${{ matrix.args }}
+          git diff > ${{ matrix.name }}.diff
+      -
+        name: Compare diff
+        run: diff -u fourmolu/compat-tests/${{ matrix.name }}.diff target/${{ matrix.name }}.diff
       -
         if: always()
         uses: actions/upload-artifact@v3

--- a/changelog.d/reexport-leading-export.md
+++ b/changelog.d/reexport-leading-export.md
@@ -1,0 +1,1 @@
+* Fixed an issue where re-exporting a module with Haddock comments + `import-exports=leading` was indented too far ([#381](https://github.com/fourmolu/fourmolu/issues/381))

--- a/compat-tests/cabal.diff
+++ b/compat-tests/cabal.diff
@@ -1,3 +1,29 @@
+diff --git a/Cabal-syntax/src/Distribution/Compat/Prelude.hs b/Cabal-syntax/src/Distribution/Compat/Prelude.hs
+index 3cbf3c1..4aa252c 100644
+--- a/Cabal-syntax/src/Distribution/Compat/Prelude.hs
++++ b/Cabal-syntax/src/Distribution/Compat/Prelude.hs
+@@ -22,7 +22,7 @@ module Distribution.Compat.Prelude
+ 
+   --
+   -- Prelude is re-exported, following is hidden:
+-      module BasePrelude
++    module BasePrelude
+ 
+     -- * Common type-classes
+   , Semigroup (..)
+diff --git a/Cabal-syntax/src/Distribution/PackageDescription.hs b/Cabal-syntax/src/Distribution/PackageDescription.hs
+index 47d4667..ffd1713 100644
+--- a/Cabal-syntax/src/Distribution/PackageDescription.hs
++++ b/Cabal-syntax/src/Distribution/PackageDescription.hs
+@@ -12,7 +12,7 @@
+ -- about @.cabal@ files.
+ module Distribution.PackageDescription
+   ( -- * PD and GPD
+-      module Distribution.Types.PackageDescription
++    module Distribution.Types.PackageDescription
+   , module Distribution.Types.GenericPackageDescription
+ 
+     -- * Components
 diff --git a/Cabal/src/Distribution/Backpack/MixLink.hs b/Cabal/src/Distribution/Backpack/MixLink.hs
 index b358612..3e4cc8d 100644
 --- a/Cabal/src/Distribution/Backpack/MixLink.hs
@@ -86,6 +112,19 @@ index 6e0f00d..010bffc 100644
            return v
  
      let req_rename_fn k = case Map.lookup k req_rename of
+diff --git a/Cabal/src/Distribution/Simple/Compiler.hs b/Cabal/src/Distribution/Simple/Compiler.hs
+index 074f2f3..0ac9d19 100644
+--- a/Cabal/src/Distribution/Simple/Compiler.hs
++++ b/Cabal/src/Distribution/Simple/Compiler.hs
+@@ -23,7 +23,7 @@
+ -- not yet fully support this latter feature.
+ module Distribution.Simple.Compiler
+   ( -- * Haskell implementations
+-      module Distribution.Compiler
++    module Distribution.Compiler
+   , Compiler (..)
+   , showCompilerId
+   , showCompilerIdWithAbi
 diff --git a/Cabal/src/Distribution/Simple/GHC.hs b/Cabal/src/Distribution/Simple/GHC.hs
 index f01d096..cd2c614 100644
 --- a/Cabal/src/Distribution/Simple/GHC.hs

--- a/data/fourmolu/import-export/input-multi.hs
+++ b/data/fourmolu/import-export/input-multi.hs
@@ -40,3 +40,13 @@ module Foo
   ( -- | asdf
     singleExport
   ) where
+
+{- // -}
+
+-- https://github.com/fourmolu/fourmolu/issues/381
+module Foo (
+    -- * Re-export of module
+    module X,
+    -- * Some other thing
+    Foo,
+) where

--- a/data/fourmolu/import-export/output-ImportExportDiffFriendly.hs
+++ b/data/fourmolu/import-export/output-ImportExportDiffFriendly.hs
@@ -39,3 +39,14 @@ module Foo (
     -- | asdf
     singleExport,
 ) where
+
+{- // -}
+
+-- https://github.com/fourmolu/fourmolu/issues/381
+module Foo (
+    -- * Re-export of module
+    module X,
+
+    -- * Some other thing
+    Foo,
+) where

--- a/data/fourmolu/import-export/output-ImportExportLeading.hs
+++ b/data/fourmolu/import-export/output-ImportExportLeading.hs
@@ -39,3 +39,14 @@ module Foo
     ( -- | asdf
       singleExport
     ) where
+
+{- // -}
+
+-- https://github.com/fourmolu/fourmolu/issues/381
+module Foo
+    ( -- * Re-export of module
+        module X
+
+      -- * Some other thing
+    , Foo
+    ) where

--- a/data/fourmolu/import-export/output-ImportExportLeading.hs
+++ b/data/fourmolu/import-export/output-ImportExportLeading.hs
@@ -45,7 +45,7 @@ module Foo
 -- https://github.com/fourmolu/fourmolu/issues/381
 module Foo
     ( -- * Re-export of module
-        module X
+      module X
 
       -- * Some other thing
     , Foo

--- a/data/fourmolu/import-export/output-ImportExportTrailing.hs
+++ b/data/fourmolu/import-export/output-ImportExportTrailing.hs
@@ -39,3 +39,14 @@ module Foo
     ( -- | asdf
       singleExport,
     ) where
+
+{- // -}
+
+-- https://github.com/fourmolu/fourmolu/issues/381
+module Foo
+    ( -- * Re-export of module
+      module X,
+
+      -- * Some other thing
+      Foo,
+    ) where

--- a/src/Ormolu/Printer/Meat/ImportExport.hs
+++ b/src/Ormolu/Printer/Meat/ImportExport.hs
@@ -104,8 +104,9 @@ p_lie encLayout isAllPrevDoc relativePos = \case
           IEWildcard n ->
             let (before, after) = splitAt n names
              in before ++ [txt ".."] ++ after
-  IEModuleContents _ l1 -> withComma $ do
-    indentDoc $ located l1 p_hsmodName
+  IEModuleContents _ l1 ->
+    withComma $
+      located l1 p_hsmodName
   IEGroup NoExtField n str -> do
     case relativePos of
       SinglePos -> return ()


### PR DESCRIPTION
Resolves https://github.com/fourmolu/fourmolu/issues/381

The immediate cause of the breakage was #344 adding a fix for the first export with only haddocks preceding. But the logic was actually correct; the incorrect behavior was that module re-exports were re-indented as docstrings:

https://github.com/fourmolu/fourmolu/blob/7a2d6dde1a9bb77ec3efc1a20c6199c194386a5d/src/Ormolu/Printer/Meat/ImportExport.hs#L103

This seems to have been an oversight in https://github.com/fourmolu/fourmolu/pull/108.

So with the fix in #344, module re-exports were indented twice in the specific case where:
1. commaStyle = Leading
2. relativePos is not SinglePos or FirstPos
3. isAllPrevDoc is True