### PR TITLE
Implement single-deriving-parens

### DIFF
--- a/changelog.d/single-deriving-parens.md
+++ b/changelog.d/single-deriving-parens.md
@@ -1,0 +1,2 @@
+Add `single-deriving-parens` configuration option to determine `deriving`
+clauses of a single type should be parenthesized. [PR 386](https://github.com/fourmolu/fourmolu/pull/386).

--- a/config/FourmoluConfig/ConfigData.hs
+++ b/config/FourmoluConfig/ConfigData.hs
@@ -218,6 +218,16 @@ allOptions =
         ormolu = HsList [],
         sinceVersion = Just "0.13.0.0",
         cliOverrides = emptyOverrides
+      },
+    Option
+      { name = "single-deriving-parens",
+        fieldName = Just "poSingleDerivingParens",
+        description = "Whether to put parentheses around a single deriving class",
+        type_ = "SingleDerivingParens",
+        default_ = HsExpr "DerivingAlways",
+        ormolu = HsExpr "DerivingAlways",
+        sinceVersion = Nothing,
+        cliOverrides = emptyOverrides
       }
   ]
 
@@ -412,5 +422,13 @@ allFieldTypes =
               "          \"Valid values are: \\\"none\\\", or an integer\"",
               "        ]"
             ]
+      },
+    FieldTypeEnum
+      { fieldTypeName = "SingleDerivingParens",
+        enumOptions =
+          [ ("DerivingAuto", "auto"),
+            ("DerivingAlways", "always"),
+            ("DerivingNever", "never")
+          ]
       }
   ]

--- a/data/fourmolu/single-deriving-parens/input.hs
+++ b/data/fourmolu/single-deriving-parens/input.hs
@@ -1,0 +1,10 @@
+module Main where
+
+data Foo = Foo
+    deriving stock Show
+
+data Bar = Bar
+    deriving stock (Show, Eq)
+
+data Bat = Bat
+    deriving stock (Show)

--- a/data/fourmolu/single-deriving-parens/output-DerivingAlways.hs
+++ b/data/fourmolu/single-deriving-parens/output-DerivingAlways.hs
@@ -1,0 +1,10 @@
+module Main where
+
+data Foo = Foo
+    deriving stock (Show)
+
+data Bar = Bar
+    deriving stock (Show, Eq)
+
+data Bat = Bat
+    deriving stock (Show)

--- a/data/fourmolu/single-deriving-parens/output-DerivingAuto.hs
+++ b/data/fourmolu/single-deriving-parens/output-DerivingAuto.hs
@@ -1,0 +1,10 @@
+module Main where
+
+data Foo = Foo
+    deriving stock Show
+
+data Bar = Bar
+    deriving stock (Show, Eq)
+
+data Bat = Bat
+    deriving stock (Show)

--- a/data/fourmolu/single-deriving-parens/output-DerivingNever.hs
+++ b/data/fourmolu/single-deriving-parens/output-DerivingNever.hs
@@ -1,0 +1,10 @@
+module Main where
+
+data Foo = Foo
+    deriving stock Show
+
+data Bar = Bar
+    deriving stock (Show, Eq)
+
+data Bat = Bat
+    deriving stock Show

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -18,3 +18,4 @@ unicode: never
 respectful: false
 fixities: []
 reexports: []
+single-deriving-parens: always

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -42,6 +42,7 @@ module Ormolu.Config
     InStyle (..),
     Unicode (..),
     ColumnLimit (..),
+    SingleDerivingParens (..),
     parsePrinterOptsCLI,
     parsePrinterOptType,
 

--- a/src/Ormolu/Diff/ParseResult.hs
+++ b/src/Ormolu/Diff/ParseResult.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeepSubsumption #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -160,5 +161,7 @@ diffHsModule = genericQuery
     classDeclCtxEq tc tc' = genericQuery tc tc'
 
     derivedTyClsParensEq :: DerivClauseTys GhcPs -> GenericQ ParseResultDiff
-    derivedTyClsParensEq (DctSingle NoExtField sigTy) dct' = genericQuery (DctMulti NoExtField [sigTy]) dct'
-    derivedTyClsParensEq dct dct' = genericQuery dct dct'
+    derivedTyClsParensEq = considerEqualVia $ curry $ \case
+      (DctSingle _ ty, DctMulti _ [ty']) -> genericQuery ty ty'
+      (DctMulti _ [ty], DctSingle _ ty') -> genericQuery ty ty'
+      (x, y) -> genericQuery x y

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -231,6 +231,15 @@ spec =
           testCaseSuffix = \(respectful, importExportStyle) ->
             suffixWith ["respectful=" ++ show respectful, show importExportStyle],
           checkIdempotence = True
+        },
+      TestGroup
+        { label = "single-deriving-parens",
+          isMulti = False,
+          testCases = allOptions,
+          updateConfig = \parens opts -> opts {poSingleDerivingParens = pure parens},
+          showTestCase = show,
+          testCaseSuffix = suffix1,
+          checkIdempotence = True
         }
     ]
 

--- a/web/site/pages/config/single-deriving-parens.md
+++ b/web/site/pages/config/single-deriving-parens.md
@@ -1,0 +1,22 @@
+# `single-deriving-parens`
+
+$info$
+
+The `auto` option will keep parentheses if they already exist, but won't add parentheses if not.
+
+## Examples
+
+```fourmolu-example-input
+data Foo = Foo
+  deriving stock Show
+```
+```fourmolu-example-tab
+With parens
+{ "single-deriving-parens": "always" }
+```
+```fourmolu-example-tab
+Without parens
+{ "single-deriving-parens": "never" }
+```
+
+For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/single-deriving-parens).


### PR DESCRIPTION
As discussed in #385.

---

### [Make derivedTyClsParensEq more rebust](https://github.com/fourmolu/fourmolu/pull/386/commits/33c7a8c575772ff9d5288c69292e973fc7f2a3b4)
[33c7a8c](https://github.com/fourmolu/fourmolu/pull/386/commits/33c7a8c575772ff9d5288c69292e973fc7f2a3b4)

The current implementation of this function relies on the fact that we
never output un-parenthesised deriving classes from formatting. This
means the right-hand argument is never a `DctSingle`. If it ever were,
the function would incorrectly return a `Difference` no matter what,
even if it were the exact same `DctSingle` as the left-hand argument.

Since we're about to start making those parenthesis conditional, this
won't work. Instead, we now use `considerEqualVia` and pattern match on
a comparison of single-to-singleton or singleton-to-single. I find this
a conceptually simpler approach anyway, and is more lenient in the way
we need.

### [Implement single-deriving-parens](https://github.com/fourmolu/fourmolu/pull/386/commits/2c8645b1b22fa49bfad4f59bb472575193b315ef)
[2c8645b](https://github.com/fourmolu/fourmolu/pull/386/commits/2c8645b1b22fa49bfad4f59bb472575193b315ef)

Analogous to `single-constraint-parens`, this option decides how
deriving clauses should parenthesis single-element lists.

The implementation logic is as follow:

- If the user typed `Show` and we are configured for "always", use
  parenthesis. Otherwise ("never" or "auto"), don't.

- If the user typed `(Show)` and we are configured for "never", don't
  use parenthesis. Otherwise ("always" or "auto"), do.

### [Add changelog snippet for single-deriving-parens](https://github.com/fourmolu/fourmolu/pull/386/commits/2c66260034843156b60fce3acef80487a1419b73)
[2c66260](https://github.com/fourmolu/fourmolu/pull/386/commits/2c66260034843156b60fce3acef80487a1419b73)