### PR TITLE
Fix the order in which the configurations are applied

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -100,8 +100,8 @@ mkConfig path Opts {optQuiet, optConfig = cliConfig, optPrinterOpts = cliPrinter
     cliConfig
       { cfgPrinterOpts =
           resolvePrinterOpts
-            [ cliPrinterOpts,
-              cfgFilePrinterOpts fourmoluConfig
+            [ cfgFilePrinterOpts fourmoluConfig,
+              cliPrinterOpts
             ],
         cfgFixityOverrides =
           FixityOverrides . mconcat . map unFixityOverrides $

--- a/changelog.d/fix-resolve-order.md
+++ b/changelog.d/fix-resolve-order.md
@@ -1,0 +1,1 @@
+* Fix the order in which the configurations are applied ([#390](https://github.com/fourmolu/fourmolu/issues/390))

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -58,6 +58,7 @@ import Control.Monad (forM)
 import Data.Aeson ((.!=), (.:?))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
+import Data.Foldable (foldl')
 import Data.Functor.Identity (Identity (..))
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
@@ -230,7 +231,7 @@ deriving instance Show PrinterOptsTotal
 
 -- | Apply the given configuration in order (later options override earlier).
 resolvePrinterOpts :: [PrinterOptsPartial] -> PrinterOptsTotal
-resolvePrinterOpts = foldr fillMissingPrinterOpts defaultPrinterOpts
+resolvePrinterOpts = foldl' (flip fillMissingPrinterOpts) defaultPrinterOpts
 
 ----------------------------------------------------------------------------
 -- Loading Fourmolu configuration

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -7,7 +7,7 @@ import Data.ByteString.Char8 qualified as Char8
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Yaml qualified as Yaml
-import Ormolu.Config (FourmoluConfig (..))
+import Ormolu.Config (FourmoluConfig (..), poIndentation, resolvePrinterOpts)
 import Ormolu.Fixity (ModuleReexports (..))
 import Test.Hspec
 
@@ -26,3 +26,8 @@ spec = do
               [ ("Foo", NonEmpty.fromList [(Nothing, "Bar2"), (Nothing, "Bar1")])
               ]
       cfgFileReexports config `shouldBe` ModuleReexports expected
+    it "applies configurations in correct order" $ do
+      let opts1 = mempty {poIndentation = Just 2}
+          opts2 = mempty {poIndentation = Just 4}
+          configs = [opts1, opts2]
+      poIndentation (resolvePrinterOpts configs) `shouldBe` 4


### PR DESCRIPTION
Fixes #390

The documentation of `resolvePrinterOpts` states that "later options override earlier", but it is not the case. This commit fixes the application order such that it is inline with the documentation.