### PR TITLE
Fix indentation in multiline tuple patterns

### DIFF
--- a/changelog.d/multiline-tuple-args.md
+++ b/changelog.d/multiline-tuple-args.md
@@ -1,0 +1,1 @@
+* Fix issue where a multiline tuple in a function argument gets indented too much

--- a/compat-tests/cabal.diff
+++ b/compat-tests/cabal.diff
@@ -459,9 +459,196 @@ index 1e08e84..4779812 100644
  noCommentsPrompt :: Interactive m => InitFlags -> m Bool
  noCommentsPrompt flags = getNoComments flags $ do
 diff --git a/cabal-install/src/Distribution/Client/Install.hs b/cabal-install/src/Distribution/Client/Install.hs
-index e1f855c..480d1e2 100644
+index e1f855c..c1eb443 100644
 --- a/cabal-install/src/Distribution/Client/Install.hs
 +++ b/cabal-install/src/Distribution/Client/Install.hs
+@@ -407,18 +407,18 @@ makeInstallContext
+ makeInstallContext
+   verbosity
+   ( packageDBs
+-    , repoCtxt
+-    , comp
+-    , _
+-    , progdb
+-    , _
+-    , _
+-    , configExFlags
+-    , installFlags
+-    , _
+-    , _
+-    , _
+-    )
++  , repoCtxt
++  , comp
++  , _
++  , progdb
++  , _
++  , _
++  , configExFlags
++  , installFlags
++  , _
++  , _
++  , _
++  )
+   mUserTargets = do
+     let idxState = flagToMaybe (installIndexState installFlags)
+ 
+@@ -472,25 +472,25 @@ makeInstallPlan
+ makeInstallPlan
+   verbosity
+   ( _
+-    , _
+-    , comp
+-    , platform
+-    , _
+-    , _
+-    , configFlags
+-    , configExFlags
+-    , installFlags
+-    , _
+-    , _
+-    , _
+-    )
++  , _
++  , comp
++  , platform
++  , _
++  , _
++  , configFlags
++  , configExFlags
++  , installFlags
++  , _
++  , _
++  , _
++  )
+   ( installedPkgIndex
+-    , sourcePkgDb
+-    , pkgConfigDb
+-    , _
+-    , pkgSpecifiers
+-    , _
+-    ) = do
++  , sourcePkgDb
++  , pkgConfigDb
++  , _
++  , pkgSpecifiers
++  , _
++  ) = do
+     notice verbosity "Resolving dependencies..."
+     return $
+       planPackages
+@@ -516,12 +516,12 @@ processInstallPlan
+   verbosity
+   args@(_, _, _, _, _, _, configFlags, _, installFlags, _, _, _)
+   ( installedPkgIndex
+-    , sourcePkgDb
+-    , _
+-    , userTargets
+-    , pkgSpecifiers
+-    , _
+-    )
++  , sourcePkgDb
++  , _
++  , userTargets
++  , pkgSpecifiers
++  , _
++  )
+   installPlan0 = do
+     checkPrintPlan
+       verbosity
+@@ -1023,18 +1023,18 @@ reportPlanningFailure
+ reportPlanningFailure
+   verbosity
+   ( _
+-    , _
+-    , comp
+-    , platform
+-    , _
+-    , _
+-    , configFlags
+-    , _
+-    , installFlags
+-    , _
+-    , _
+-    , _
+-    )
++  , _
++  , comp
++  , platform
++  , _
++  , _
++  , configFlags
++  , _
++  , installFlags
++  , _
++  , _
++  , _
++  )
+   (_, sourcePkgDb, _, _, pkgSpecifiers, _)
+   message = do
+     when reportFailure $ do
+@@ -1122,18 +1122,18 @@ postInstallActions
+ postInstallActions
+   verbosity
+   ( packageDBs
+-    , _
+-    , comp
+-    , platform
+-    , progdb
+-    , globalFlags
+-    , configFlags
+-    , _
+-    , installFlags
+-    , _
+-    , _
+-    , _
+-    )
++  , _
++  , comp
++  , platform
++  , progdb
++  , globalFlags
++  , configFlags
++  , _
++  , installFlags
++  , _
++  , _
++  , _
++  )
+   _
+   installPlan
+   buildOutcomes = do
+@@ -1413,18 +1413,18 @@ performInstallations
+ performInstallations
+   verbosity
+   ( packageDBs
+-    , repoCtxt
+-    , comp
+-    , platform
+-    , progdb
+-    , globalFlags
+-    , configFlags
+-    , configExFlags
+-    , installFlags
+-    , haddockFlags
+-    , testFlags
+-    , _
+-    )
++  , repoCtxt
++  , comp
++  , platform
++  , progdb
++  , globalFlags
++  , configFlags
++  , configExFlags
++  , installFlags
++  , haddockFlags
++  , testFlags
++  , _
++  )
+   installedPkgIndex
+   installPlan = do
+     info verbosity $ "Number of threads used: " ++ (show numJobs) ++ "."
 @@ -1750,7 +1750,7 @@ installLocalTarballPackage
              descFilePath =
                absUnpackedPath
@@ -512,6 +699,29 @@ index b032110..92f720d 100644
        $+$ nest
          4
          ( vcat
+diff --git a/cabal-install/src/Distribution/Client/Main.hs b/cabal-install/src/Distribution/Client/Main.hs
+index 5959753..8009908 100644
+--- a/cabal-install/src/Distribution/Client/Main.hs
++++ b/cabal-install/src/Distribution/Client/Main.hs
+@@ -741,12 +741,12 @@ installAction (configFlags, _, installFlags, _, _, _) _ globalFlags
+         (const [])
+ installAction
+   ( configFlags
+-    , configExFlags
+-    , installFlags
+-    , haddockFlags
+-    , testFlags
+-    , benchmarkFlags
+-    )
++  , configExFlags
++  , installFlags
++  , haddockFlags
++  , testFlags
++  , benchmarkFlags
++  )
+   extraArgs
+   globalFlags = do
+     let verb = fromFlagOrDefault normal (configVerbosity configFlags)
 diff --git a/cabal-install/src/Distribution/Client/ParseUtils.hs b/cabal-install/src/Distribution/Client/ParseUtils.hs
 index 44cdc4c..f79c10d 100644
 --- a/cabal-install/src/Distribution/Client/ParseUtils.hs

--- a/data/examples/declaration/value/function/arrow/proc-applications-four-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-applications-four-out.hs
@@ -7,9 +7,9 @@ foolr x = proc a -> x >- a
 bar f x =
     proc
         ( y
-            , z
-            , w
-            )
+        , z
+        , w
+        )
     ->
         f -- The value
             -<

--- a/data/examples/declaration/value/function/arrow/proc-applications-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-applications-out.hs
@@ -9,7 +9,7 @@ bar f x =
     ( y,
       z,
       w
-      )
+    )
   ->
     f -- The value
       -<

--- a/data/examples/declaration/value/function/arrow/proc-do-complex-four-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex-four-out.hs
@@ -7,9 +7,9 @@ foo
     ma =
         proc
             ( (a, b)
-                , (c, d)
-                , (e, f)
-                )
+            , (c, d)
+            , (e, f)
+            )
         -> do
             -- Begin do
             (x, y) <- -- GHC parser fails if layed out over multiple lines

--- a/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
+++ b/data/examples/declaration/value/function/arrow/proc-do-complex-out.hs
@@ -9,7 +9,7 @@ foo
       ( (a, b),
         (c, d),
         (e, f)
-        )
+      )
     -> do
       -- Begin do
       (x, y) <- -- GHC parser fails if layed out over multiple lines

--- a/data/examples/fourmolu/multiline-tuples-four-out.hs
+++ b/data/examples/fourmolu/multiline-tuples-four-out.hs
@@ -2,15 +2,15 @@
 
 multilineFunction
     ( a
-        , b
-        , c
-        ) = a + b + c
+    , b
+    , c
+    ) = a + b + c
 
 multilineLambda =
     \( a
-        , b
-        , c
-        ) -> a + b + c
+     , b
+     , c
+     ) -> a + b + c
 
 multilineCase = \case
     ( a
@@ -42,6 +42,6 @@ multilineQuasi =
 
 pattern MultilineSynonym =
     ( 1
-        , 2
-        , 3
-        )
+    , 2
+    , 3
+    )

--- a/data/examples/fourmolu/multiline-tuples-four-out.hs
+++ b/data/examples/fourmolu/multiline-tuples-four-out.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+multilineFunction
+    ( a
+        , b
+        , c
+        ) = a + b + c
+
+multilineLambda =
+    \( a
+        , b
+        , c
+        ) -> a + b + c
+
+multilineCase = \case
+    ( a
+        , b
+        , c
+        ) -> a + b + c
+
+multilineDo = do
+    ( a
+        , b
+        , c
+        ) <-
+        _
+    pure $ a + b + c
+
+multilineQuasi =
+    [p|
+        ( a
+        , b
+        , c
+        )
+    |]
+
+-- top level
+( a
+    , b
+    , c
+    ) = (1, 2, 3)
+
+pattern MultilineSynonym =
+    ( 1
+        , 2
+        , 3
+        )

--- a/data/examples/fourmolu/multiline-tuples-out.hs
+++ b/data/examples/fourmolu/multiline-tuples-out.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+multilineFunction
+  ( a,
+    b,
+    c
+    ) = a + b + c
+
+multilineLambda =
+  \( a,
+     b,
+     c
+    ) -> a + b + c
+
+multilineCase = \case
+  ( a,
+    b,
+    c
+    ) -> a + b + c
+
+multilineDo = do
+  ( a,
+    b,
+    c
+    ) <-
+    _
+  pure $ a + b + c
+
+multilineQuasi =
+  [p|
+        ( a
+        , b
+        , c
+        )
+    |]
+
+-- top level
+( a,
+  b,
+  c
+  ) = (1, 2, 3)
+
+pattern MultilineSynonym =
+  ( 1,
+    2,
+    3
+    )

--- a/data/examples/fourmolu/multiline-tuples-out.hs
+++ b/data/examples/fourmolu/multiline-tuples-out.hs
@@ -4,13 +4,13 @@ multilineFunction
   ( a,
     b,
     c
-    ) = a + b + c
+  ) = a + b + c
 
 multilineLambda =
   \( a,
      b,
      c
-    ) -> a + b + c
+   ) -> a + b + c
 
 multilineCase = \case
   ( a,
@@ -44,4 +44,4 @@ pattern MultilineSynonym =
   ( 1,
     2,
     3
-    )
+  )

--- a/data/examples/fourmolu/multiline-tuples.hs
+++ b/data/examples/fourmolu/multiline-tuples.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+multilineFunction
+    ( a
+        , b
+            , c
+                ) = a + b + c
+
+multilineLambda =
+    \( a
+        , b
+            , c
+                ) -> a + b + c
+
+multilineCase = \case
+    ( a
+        , b
+            , c
+                ) -> a + b + c
+
+multilineDo = do
+    ( a
+        , b
+            , c
+                ) <- _
+    pure $ a + b + c
+
+multilineQuasi =
+    [p|
+        ( a
+        , b
+        , c
+        )
+    |]
+
+-- top level
+( a
+    , b
+        , c
+            ) = (1, 2, 3)
+
+pattern MultilineSynonym =
+    ( 1
+        , 2
+            , 3
+                )

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -210,14 +210,14 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
           patSpans = combineSrcSpans' (getLocA <$> ne_pats)
           indentBody = not (isOneLineSpan combinedSpans)
       switchLayoutNoLimit [combinedSpans] $ do
-        let stdCase = sep breakpoint (located' p_pat) m_pats
+        let stdCase = sep breakpoint (located' p_pat') m_pats
         case style of
           Function name ->
             p_infixDefHelper
               isInfix
               indentBody
               (p_rdrName name)
-              (located' p_pat <$> m_pats)
+              (located' p_pat' <$> m_pats)
           PatternBind -> stdCase
           Case -> stdCase
           Lambda -> do
@@ -231,12 +231,12 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
             when needsSpace space
             sitcc stdCase
           LambdaCase -> do
-            located' p_pat head_pat
+            located' p_pat' head_pat
             unless (null tail_pats) $ do
               breakpoint
               -- When we have multiple patterns (with `\cases`) across multiple
               -- lines, we have to indent all but the first pattern.
-              inci $ sep breakpoint (located' p_pat) tail_pats
+              inci $ sep breakpoint (located' p_pat') tail_pats
       return indentBody
   let -- Calculate position of end of patterns. This is useful when we decide
       -- about putting certain constructions in hanging positions.
@@ -297,6 +297,15 @@ p_match' placer render style isInfix multAnn strictness m_pats GRHSs {..} = do
     switchLayout [patGrhssSpan] $
       placeHanging placement p_body
     inci p_where
+  where
+    p_pat' =
+      p_pat $
+        case style of
+          Function {} -> PatternCtxFunction
+          PatternBind {} -> PatternCtxTopLevel
+          Case {} -> PatternCtxCase
+          Lambda {} -> PatternCtxFunction
+          LambdaCase {} -> PatternCtxCase
 
 p_grhs :: GroupStyle -> GRHS GhcPs (LHsExpr GhcPs) -> R ()
 p_grhs = p_grhs' Normal exprPlacement p_hsExpr
@@ -438,7 +447,7 @@ p_stmt' ::
 p_stmt' placer render = \case
   LastStmt _ body _ _ -> located body render
   BindStmt _ p f@(getLocA -> l) -> do
-    located p p_pat
+    located p (p_pat PatternCtxDoBlock)
     space
     token'larrow
     let loc = getLocA p
@@ -871,7 +880,7 @@ p_hsExpr' isApp s = \case
     txt "proc"
     located p $ \x -> do
       breakpoint
-      inci (p_pat x)
+      inci (p_pat PatternCtxFunction x)
       breakpoint
     token'rarrow
     placeHanging (cmdTopPlacement (unLoc e)) $
@@ -903,17 +912,17 @@ p_patSynBind PSB {..} = do
             switchLayout pattern_def_spans $ do
               token'larrow
               breakpoint
-              located psb_def p_pat
+              located psb_def (p_pat PatternCtxPatSynonym)
           ImplicitBidirectional ->
             switchLayout pattern_def_spans $ do
               equals
               breakpoint
-              located psb_def p_pat
+              located psb_def (p_pat PatternCtxPatSynonym)
           ExplicitBidirectional mgroup -> do
             switchLayout pattern_def_spans $ do
               token'larrow
               breakpoint
-              located psb_def p_pat
+              located psb_def (p_pat PatternCtxPatSynonym)
             breakpoint
             txt "where"
             breakpoint
@@ -1146,64 +1155,81 @@ p_let' inDo letLoc localBinds mBody = do
         EpaSpan (RealSrcSpan r _) -> Just $ srcSpanStartLine r
         _ -> Nothing
 
-p_pat :: Pat GhcPs -> R ()
-p_pat = \case
+data PatternContext
+  = PatternCtxFunction
+  | PatternCtxCase
+  | PatternCtxDoBlock
+  | PatternCtxQuasi
+  | PatternCtxTopLevel
+  | PatternCtxPatSynonym
+
+p_pat :: PatternContext -> Pat GhcPs -> R ()
+p_pat ctx = \case
   WildPat _ -> txt "_"
   VarPat _ name -> p_rdrName name
   LazyPat _ pat -> do
     txt "~"
-    located pat p_pat
+    located pat p_pat'
   AsPat _ name pat -> do
     p_rdrName name
     txt "@"
-    located pat p_pat
+    located pat p_pat'
   ParPat _ pat ->
-    located pat (parens S . sitcc . p_pat)
+    located pat (parens S . sitcc . p_pat')
   BangPat _ pat -> do
     txt "!"
-    located pat p_pat
+    located pat p_pat'
   ListPat _ pats ->
-    brackets S $ sep commaDel (located' p_pat) pats
+    brackets S $ sep commaDel (located' p_pat') pats
   TuplePat _ pats boxing -> do
+    let parenStyle =
+          -- don't indent closing paren if possible, because it's
+          -- prettier. but closing paren must be indented in certain
+          -- scenarios or it's a syntax error.
+          case ctx of
+            PatternCtxCase -> S
+            PatternCtxTopLevel -> S
+            PatternCtxDoBlock -> S
+            _ -> N
     let parens' =
           case boxing of
-            Boxed -> parens S
-            Unboxed -> parensHash S
-    parens' $ sep commaDel (sitcc . located' p_pat) pats
+            Boxed -> parens
+            Unboxed -> parensHash
+    parens' parenStyle $ sep commaDel (sitcc . located' p_pat') pats
   SumPat _ pat tag arity ->
-    p_unboxedSum S tag arity (located pat p_pat)
+    p_unboxedSum S tag arity (located pat p_pat')
   ConPat _ pat details ->
     case details of
       PrefixCon tys xs -> sitcc $ do
         p_rdrName pat
         unless (null tys && null xs) breakpoint
         inci . sitcc $
-          sep breakpoint (sitcc . either p_hsConPatTyArg (located' p_pat)) $
+          sep breakpoint (sitcc . either p_hsConPatTyArg (located' p_pat')) $
             (Left <$> tys) <> (Right <$> xs)
       RecCon (HsRecFields fields dotdot) -> do
         p_rdrName pat
         breakpointPreRecordBrace
         let f = \case
               Nothing -> txt ".."
-              Just x -> located x p_pat_hsFieldBind
+              Just x -> located x (p_pat_hsFieldBind ctx)
         inci . braces N . sep commaDel f $
           case dotdot of
             Nothing -> Just <$> fields
             Just (L _ (RecFieldsDotDot n)) -> (Just <$> take n fields) ++ [Nothing]
       InfixCon l r -> do
         switchLayout [getLocA l, getLocA r] $ do
-          located l p_pat
+          located l p_pat'
           breakpoint
           inci $ do
             p_rdrName pat
             space
-            located r p_pat
+            located r p_pat'
   ViewPat _ expr pat -> sitcc $ do
     located expr p_hsExpr
     space
     token'rarrow
     breakpoint
-    inci (located pat p_pat)
+    inci (located pat p_pat')
   SplicePat _ splice -> p_hsUntypedSplice DollarSplice splice
   LitPat _ p -> atom p
   NPat _ v (isJust -> isNegated) _ -> do
@@ -1220,13 +1246,15 @@ p_pat = \case
       space
       located k (atom . ol_val)
   SigPat _ pat HsPS {..} -> do
-    located pat p_pat
+    located pat p_pat'
     p_typeAscription (lhsTypeToSigType hsps_body)
   EmbTyPat _ (HsTP _ ty) -> do
     txt "type"
     space
     located ty p_hsType
   InvisPat _ tyPat -> p_tyPat tyPat
+  where
+    p_pat' = p_pat ctx
 
 p_tyPat :: HsTyPat GhcPs -> R ()
 p_tyPat (HsTP _ ty) = txt "@" *> located ty p_hsType
@@ -1234,14 +1262,14 @@ p_tyPat (HsTP _ ty) = txt "@" *> located ty p_hsType
 p_hsConPatTyArg :: HsConPatTyArg GhcPs -> R ()
 p_hsConPatTyArg (HsConPatTyArg _ patSigTy) = p_tyPat patSigTy
 
-p_pat_hsFieldBind :: HsRecField GhcPs (LPat GhcPs) -> R ()
-p_pat_hsFieldBind HsFieldBind {..} = do
+p_pat_hsFieldBind :: PatternContext -> HsRecField GhcPs (LPat GhcPs) -> R ()
+p_pat_hsFieldBind ctx HsFieldBind {..} = do
   located hfbLHS p_fieldOcc
   unless hfbPun $ do
     space
     equals
     breakpoint
-    inci (located hfbRHS p_pat)
+    inci (located hfbRHS (p_pat ctx))
 
 p_unboxedSum :: BracketStyle -> ConTag -> Arity -> R () -> R ()
 p_unboxedSum s tag arity m = do
@@ -1294,7 +1322,7 @@ p_hsQuote anns = \case
           | any (isJust . matchAddEpAnn AnnOpenEQ) anns = ""
           | otherwise = "e"
     quote name (located expr p_hsExpr)
-  PatBr _ pat -> located pat (quote "p" . p_pat)
+  PatBr _ pat -> located pat (quote "p" . p_pat PatternCtxQuasi)
   DecBrL _ decls -> quote "d" (handleStarIsType decls (p_hsDecls Free decls))
   DecBrG _ _ -> notImplemented "DecBrG" -- result of renamer
   TypBr _ ty -> quote "t" (located ty (handleStarIsType ty . p_hsType))

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -7,7 +7,6 @@
 
 module Ormolu.Printer.Meat.Declaration.Value
   ( p_valDecl,
-    p_pat,
     p_hsExpr,
     p_hsUntypedSplice,
     p_stringLit,

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs-boot
@@ -1,6 +1,5 @@
 module Ormolu.Printer.Meat.Declaration.Value
   ( p_valDecl,
-    p_pat,
     p_hsExpr,
     p_hsUntypedSplice,
     p_stringLit,
@@ -16,7 +15,6 @@ import GHC.Hs
 import Ormolu.Printer.Combinators
 
 p_valDecl :: HsBindLR GhcPs GhcPs -> R ()
-p_pat :: Pat GhcPs -> R ()
 p_hsExpr :: HsExpr GhcPs -> R ()
 p_hsUntypedSplice :: SpliceDecoration -> HsUntypedSplice GhcPs -> R ()
 p_stringLit :: FastString -> R ()


### PR DESCRIPTION
This formatting behavior was discovered in https://github.com/fourmolu/fourmolu/issues/400. It's partially an issue in Ormolu (https://github.com/tweag/ormolu/pull/1101), but it's more egregious with leading commas.

Hold off on merging this until https://github.com/tweag/ormolu/pull/1101 is resolved; if it's accepted upstream, we can hold off on this and rebase after merging Ormolu in