### PR TITLE
Relax upper bound to admit ansi-terminal-1.1.1

### DIFF
--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -108,7 +108,7 @@ library
         Cabal-syntax >=3.10 && <3.11,
         Diff >=0.4 && <1,
         MemoTrie >=0.6 && <0.7,
-        ansi-terminal >=0.10 && <1.1,
+        ansi-terminal >=0.10 && <1.2,
         array >=0.5 && <0.6,
         base >=4.14 && <5,
         binary >=0.8 && <0.9,


### PR DESCRIPTION
Motivation: this is blocking the reintroduction of `ansi-terminal-1.1.x` to nightly snapshots. See: https://github.com/commercialhaskell/stackage/pull/7420#issuecomment-2110842180