### PR TITLE
Fix end-of-file newlines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,13 @@
+exclude: |
+  (?x)^(
+    region-tests/
+    | fixity-tests/
+    | data/examples/
+    | data/fourmolu/
+    | data/diff-tests/
+    | data/parse-failures/
+  )
+
 repos:
   - repo: local
     hooks:
@@ -6,22 +16,13 @@ repos:
         entry: scripts/run-fourmolu.sh --mode=inplace
         language: system
         files: '\.(hs|hs-boot)$'
-        exclude: |
-          (?x)^(
-            region-tests/
-            | fixity-tests/
-            | data/examples/
-            | data/fourmolu/
-            | data/diff-tests/
-            | data/parse-failures/
-          )
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-merge-conflict
       - id: check-symlinks
+      - id: end-of-file-fixer
       # do not turn these on, to prevent merge conflicts when
       # merging upstream ormolu changes
-      # - id: end-of-file-fixer
       # - id: trailing-whitespace

--- a/web/site/pages/config/comma-style.md
+++ b/web/site/pages/config/comma-style.md
@@ -32,4 +32,3 @@ For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tre
 ## See also
 
 * [`import-export-style`](/config/import-export-style)
-

--- a/web/site/pages/config/import-export-style.md
+++ b/web/site/pages/config/import-export-style.md
@@ -35,4 +35,3 @@ For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tre
 ## See also
 
 * [`comma-style`](/config/comma-style)
-


### PR DESCRIPTION
Even if Ormolu has bad newlines, the merge conflicts shouldn't be that bad. Let's just fix them