### PR TITLE
RFC: Add policy for breaking changes

### DIFF
--- a/.github/workflows/pr-review-comment.yml
+++ b/.github/workflows/pr-review-comment.yml
@@ -23,4 +23,5 @@ jobs:
             - [ ] Diff files in `compat-tests/` either:
                 1. Have NOT been changed, or
                 2. Modifies `fourmolu.yaml` with an appropriate option to keep the same formatting, or
-                3. Modifies Haskell files with new formatting (ONLY as a last resort)
+                3. Modifies Haskell files with new formatting
+                    * ONLY as a last resort - see [Breaking changes policy](https://github.com/fourmolu/fourmolu#breaking-changes-policy)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 * [Troubleshooting](#troubleshooting)
     * [Operators are being formatted weirdly!](#operators-are-being-formatted-weirdly)
 * [Limitations](#limitations)
+* [Breaking changes policy](#breaking-changes-policy)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -268,7 +269,18 @@ You can see how Ormolu decides the fixity of operators if you use `--debug`.
   declarations. See the [CPP](https://github.com/tweag/ormolu/blob/master/DESIGN.md#cpp) section in the design notes for a
   discussion of the dangers.
 * Various minor idempotence issues, most of them are related to comments or column limits.
-* Fourmolu is in a fairly early stage of development. The implementation should be as stable as Ormolu, as it only makes minimal changes, and is extensively tested. But the default configuration style may change in some minor ways in the near future, as we make more options available. It will always be possible to replicate the old default behaviour with a suitable `fourmolu.yaml`.
+
+## Breaking changes policy
+
+Fourmolu is still in a relatively early stage of development, but it is in wide enough use that stability is a desirable property. Fourmolu aims to uphold the following principles:
+
+1. It will always be possible to replicate Ormolu's formatting with a suitable `fourmolu.yaml`
+
+1. Breaking changes will be avoided where possible, but may still occur in the following circumstances:
+
+  * Fourmolu inherits a breaking change from Ormolu
+  * The change reverts a prior breaking change, which caused a regression
+  * Other exceptional situations, on a case-by-case basis
 
 ## Contributing
 


### PR DESCRIPTION
## Context + Motivation

While Fourmolu remains configurable, certain changes may still be breaking, e.g. if Ormolu makes a breaking change, or if no one would use the old format if not for old Fourmolu behavior. Generally, people should always be pinning a Fourmolu version in a project, but sometimes upgrades are required, e.g. when upgrading a project to use a newer GHC version. Simply upgrading a codebase to use a newer GHC can be a difficult task (e.g. https://github.com/haskell/core-libraries-committee/issues/12#issuecomment-971794515), so it can be frustrating when you realize you also have to reformat the codebase because upgrading to a version of Fourmolu that supports the new GHC version includes breaking changes. Somewhat relevant discussions: https://github.com/fourmolu/fourmolu/issues/363, https://github.com/fourmolu/fourmolu/issues/345

At the same time, we don't want to support backwards compatibility flags indefinitely, as it makes merging Ormolu changes increasingly difficult. But perhaps there's a middle ground. Regardless, we should make such a policy explicit.

## Options

There are two possible policies for breaking changes I can see Fourmolu adopting:

1. Status quo: Fourmolu will do its best to avoid breaking changes, but it may still happen. When upgrading Fourmolu, you might have to reformat at the same time. If you're upgrading GHC, you should probably upgrade Fourmolu first + reformat, then finish upgrading GHC.
2. This PR: Fourmolu will always guard breaking changes (even ones from Ormolu) until Fourmolu releases a version on the next GHC version.

The benefit of policy (2) is it gives users a transition period of at least 6 months (given GHC's release timeline is every 6 months). The downside is it adds the maintenance burden of a new flag for every breaking Ormolu change in the next 6 months. The question here is: _**Is it worth having this transition period if it's going to be required to reformat at some point anyway?**_

## User feedback - Cabal

[Cabal](https://github.com/haskell/cabal) is probably the biggest project using Fourmolu, so we added a backwards compatibility test in #346 to surface breaking changes against the Cabal codebase. In a recent PR (#429), we saw a large reformat in the Cabal codebase, which led to a discussion in the comments with Cabal maintainers.

To align on the issue, I (Brandon) joined the biweekly Cabal maintainers' meeting on 2024-08-15, and explained the issue. Namely, that certain reformattings don't make sense to allow configuring indefinitely. In this particular case, the current formatting is inconsistent with Ormolu, and this brings Fourmolu back to consistency.

In the meeting, the group agreed that these sort of breaking changes make sense, and are reasonable. They resolved to upgrade Fourmolu on a regular basis (every 6 months?), and to accept the reformat regularly, even adding to their release checklist to consider upgrading Fourmolu + reformat before making the branch cut for a release. So regardless whatever policy Fourmolu adopts, it probably won't affect Cabal.

## PR TODO's

If policy (2) is accepted, finish doing the following:

- [ ] Implement `backwards-compat-single-line-args`
- [ ] Implement `backwards-compat-list-comp-indent`
- [ ] Update diffs in `compat-tests/` to turn on backwards compat options

If policy (1) is accepted, close this PR, but open a new one that explicitly documents the policy.