### PR TITLE
Sort constraints in contexts

### DIFF
--- a/changelog.d/sort-constraints.md
+++ b/changelog.d/sort-constraints.md
@@ -1,0 +1,3 @@
+# `sort-constraints`
+
+This adds a configuration to sort constraints. The constraints are sorted in alphabetical order.

--- a/config/FourmoluConfig/ConfigData.hs
+++ b/config/FourmoluConfig/ConfigData.hs
@@ -248,6 +248,16 @@ allOptions =
         ormolu = HsList [],
         sinceVersion = Nothing,
         cliOverrides = emptyOverrides
+      },
+    Option
+      { name = "sort-constraints",
+        fieldName = Just "poSortConstraints",
+        description = "Whether to sort constraints",
+        type_ = "Bool",
+        default_ = HsBool False,
+        ormolu = HsBool False,
+        sinceVersion = Nothing,
+        cliOverrides = emptyOverrides
       }
   ]
 

--- a/data/fourmolu/sort-constraints/input.hs
+++ b/data/fourmolu/sort-constraints/input.hs
@@ -1,0 +1,43 @@
+module Main where
+
+f1 :: (Show a, Eq a) => a
+f1 a = a
+
+f2 ::
+  (Show a
+  , Eq a)
+  => a
+f2 a = a
+
+-- We don't currently realise that the inner tuple type
+-- is a constraint tuple.
+f3 ::
+  ( Generic a
+  , (Show a, Num a)
+  , Eq a)
+  => a
+f3 a = a
+
+f4 ::
+  (Show a, Num a)
+  =>
+  Eq a
+  => a
+f4 a = a
+
+f5 ::
+  (Show a
+  -- an interloping comment
+  , Eq a)
+  => a
+f5 a = a
+
+class (Show a, Eq a) => Class1 a where
+
+data (Generic a, (Show a, Eq a)) => A a
+
+deriving instance (Show a, Eq a) => Class1 Int
+
+-- We can't know this is a constraint tuple type rather than a normal
+-- tuple type without type information
+type MyConstraints a = (Show a, Eq a)

--- a/data/fourmolu/sort-constraints/output-False.hs
+++ b/data/fourmolu/sort-constraints/output-False.hs
@@ -1,0 +1,45 @@
+module Main where
+
+f1 :: (Show a, Eq a) => a
+f1 a = a
+
+f2 ::
+    ( Show a
+    , Eq a
+    ) =>
+    a
+f2 a = a
+
+-- We don't currently realise that the inner tuple type
+-- is a constraint tuple.
+f3 ::
+    ( Generic a
+    , (Show a, Num a)
+    , Eq a
+    ) =>
+    a
+f3 a = a
+
+f4 ::
+    (Show a, Num a) =>
+    (Eq a) =>
+    a
+f4 a = a
+
+f5 ::
+    ( Show a
+    , -- an interloping comment
+      Eq a
+    ) =>
+    a
+f5 a = a
+
+class (Show a, Eq a) => Class1 a
+
+data (Generic a, (Show a, Eq a)) => A a
+
+deriving instance (Show a, Eq a) => Class1 Int
+
+-- We can't know this is a constraint tuple type rather than a normal
+-- tuple type without type information
+type MyConstraints a = (Show a, Eq a)

--- a/data/fourmolu/sort-constraints/output-True.hs
+++ b/data/fourmolu/sort-constraints/output-True.hs
@@ -1,0 +1,45 @@
+module Main where
+
+f1 :: (Eq a, Show a) => a
+f1 a = a
+
+f2 ::
+    ( Eq a
+    , Show a
+    ) =>
+    a
+f2 a = a
+
+-- We don't currently realise that the inner tuple type
+-- is a constraint tuple.
+f3 ::
+    ( (Show a, Num a)
+    , Eq a
+    , Generic a
+    ) =>
+    a
+f3 a = a
+
+f4 ::
+    (Num a, Show a) =>
+    (Eq a) =>
+    a
+f4 a = a
+
+f5 ::
+    ( -- an interloping comment
+      Eq a
+    , Show a
+    ) =>
+    a
+f5 a = a
+
+class (Eq a, Show a) => Class1 a
+
+data ((Show a, Eq a), Generic a) => A a
+
+deriving instance (Eq a, Show a) => Class1 Int
+
+-- We can't know this is a constraint tuple type rather than a normal
+-- tuple type without type information
+type MyConstraints a = (Show a, Eq a)

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -21,3 +21,4 @@ fixities: []
 reexports: []
 import-grouping: legacy
 local-modules: []
+sort-constraints: false

--- a/src/Ormolu/Config/Gen.hs
+++ b/src/Ormolu/Config/Gen.hs
@@ -77,6 +77,8 @@ data PrinterOpts f =
       poRespectful :: f Bool
     , -- | Rules for grouping import declarations
       poImportGrouping :: f ImportGrouping
+    , -- | Whether to sort constraints
+      poSortConstraints :: f Bool
     }
   deriving (Generic)
 
@@ -100,6 +102,7 @@ emptyPrinterOpts =
     , poUnicode = Nothing
     , poRespectful = Nothing
     , poImportGrouping = Nothing
+    , poSortConstraints = Nothing
     }
 
 defaultPrinterOpts :: PrinterOpts Identity
@@ -122,6 +125,7 @@ defaultPrinterOpts =
     , poUnicode = pure UnicodeNever
     , poRespectful = pure True
     , poImportGrouping = pure ImportGroupLegacy
+    , poSortConstraints = pure False
     }
 
 -- | Fill the field values that are 'Nothing' in the first argument
@@ -151,6 +155,7 @@ fillMissingPrinterOpts p1 p2 =
     , poUnicode = maybe (poUnicode p2) pure (poUnicode p1)
     , poRespectful = maybe (poRespectful p2) pure (poRespectful p1)
     , poImportGrouping = maybe (poImportGrouping p2) pure (poImportGrouping p1)
+    , poSortConstraints = maybe (poSortConstraints p2) pure (poSortConstraints p1)
     }
 
 parsePrinterOptsCLI ::
@@ -227,6 +232,10 @@ parsePrinterOptsCLI f =
       "import-grouping"
       "Rules for grouping import declarations (default: legacy)"
       "OPTION"
+    <*> f
+      "sort-constraints"
+      "Whether to sort constraints (default: false)"
+      "BOOL"
 
 parsePrinterOptsJSON ::
   Applicative f =>
@@ -251,6 +260,7 @@ parsePrinterOptsJSON f =
     <*> f "unicode"
     <*> f "respectful"
     <*> f "import-grouping"
+    <*> f "sort-constraints"
 
 {---------- PrinterOpts field types ----------}
 
@@ -641,4 +651,7 @@ defaultPrinterOptsYaml =
     , ""
     , "# Modules defined by the current Cabal package for import grouping"
     , "local-modules: []"
+    , ""
+    , "# Whether to sort constraints"
+    , "sort-constraints: false"
     ]

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -26,6 +26,7 @@ where
 import Control.Monad
 import Data.Choice (pattern With, pattern Without)
 import Data.Functor ((<&>))
+import Data.List (sortOn)
 import GHC.Data.Strict qualified as Strict
 import GHC.Hs hiding (isPromoted)
 import GHC.Types.SourceText
@@ -268,7 +269,10 @@ p_hsContext :: HsContext GhcPs -> R ()
 p_hsContext = \case
   [] -> txt "()"
   [x] -> located x p_hsType
-  xs -> parens N $ sep commaDel (sitcc . located' p_hsType) xs
+  xs -> do
+    shouldSort <- getPrinterOpt poSortConstraints
+    let sort = if shouldSort then sortOn showOutputable else id
+    parens N $ sep commaDel (sitcc . located' p_hsType) (sort xs)
 
 class IsTyVarBndrFlag flag where
   isInferred :: flag -> Bool

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -318,6 +318,15 @@ spec =
           showTestCase = showStrategy,
           testCaseSuffix = \igs -> suffixWith [showStrategy igs],
           checkIdempotence = True
+        },
+      TestGroup
+        { label = "sort-constraints",
+          isMulti = False,
+          testCases = allOptions,
+          updateConfig = \sortConstraints options -> options {poSortConstraints = pure sortConstraints},
+          showTestCase = show,
+          testCaseSuffix = suffix1,
+          checkIdempotence = True
         }
     ]
 

--- a/web/site/pages/config/sort-constraints.md
+++ b/web/site/pages/config/sort-constraints.md
@@ -1,0 +1,26 @@
+# `sort-constraints`
+
+$info$
+
+This option determines whether or not to sort constraints. 
+
+The sorting applies wherever we can determine that a constraint tuple is in fact a constraint tuple type (and not a normal tuple type).
+In some situations we cannot determine this and so the constraints are not sorted.
+
+Note that using this option may result in comments inside constraints being moved to unexpected locations.
+
+## Examples
+
+```fourmolu-example-input
+f :: (Show a, Eq a) => a
+```
+```fourmolu-example-tab
+With sorting
+{ "sort-constraints": "true" }
+```
+```fourmolu-example-tab
+Without sorting
+{ "sort-constraints": "false" }
+```
+
+For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/sort-constraints).


### PR DESCRIPTION
This adds some simple sorting of constraints. There are a few potential deficiencies:

1. It doesn't sort nested constraint tuples. We could solve this by carrying around some information about whether we are in a constraint context in `p_hsType`, but that seeemed moderately disruptive.
2. It doesn't handle constraint tuple synonyms. I think this is unavoidable since we can't know they're constraint tuples without type information.
3. The sorting is very crude, just sorting on the `Outputable` representation of  the type. I think this will more-or-less doe what people expect, but perhaps it's too expensive?

Fixes #247