### PR TITLE
Add configuration options for sorting deriving clauses and types

### DIFF
--- a/changelog.d/sort-derived-classes.md
+++ b/changelog.d/sort-derived-classes.md
@@ -1,0 +1,3 @@
+# `sort-derived-classes`
+
+This adds a configuration option to sort the classes in deriving clauses.

--- a/changelog.d/sort-deriving-clauses.md
+++ b/changelog.d/sort-deriving-clauses.md
@@ -1,0 +1,3 @@
+# `sort-deriving-clauses`
+
+This adds a configuration option to sort deriving clauses.

--- a/config/FourmoluConfig/ConfigData.hs
+++ b/config/FourmoluConfig/ConfigData.hs
@@ -258,6 +258,26 @@ allOptions =
         ormolu = HsBool False,
         sinceVersion = Nothing,
         cliOverrides = emptyOverrides
+      },
+    Option
+      { name = "sort-derived-classes",
+        fieldName = Just "poSortDerivedClasses",
+        description = "Whether to sort derived classes",
+        type_ = "Bool",
+        default_ = HsBool False,
+        ormolu = HsBool False,
+        sinceVersion = Nothing,
+        cliOverrides = emptyOverrides
+      },
+    Option
+      { name = "sort-deriving-clauses",
+        fieldName = Just "poSortDerivingClauses",
+        description = "Whether to sort deriving clauses",
+        type_ = "Bool",
+        default_ = HsBool False,
+        ormolu = HsBool False,
+        sinceVersion = Nothing,
+        cliOverrides = emptyOverrides
       }
   ]
 

--- a/data/fourmolu/sort-derived-classes/input.hs
+++ b/data/fourmolu/sort-derived-classes/input.hs
@@ -1,0 +1,18 @@
+module Main where
+
+data A
+  deriving (Show, Eq, Ord)
+
+newtype B = B Int
+  deriving newtype (Num)
+  deriving stock (Show, Eq, Generic)
+  deriving (Semigroup, Monoid) via (Generically B)
+  deriving stock (Ord, Generic)
+  deriving (ToJSON)
+
+data C
+  deriving 
+    (Show
+    , Eq
+    -- A comment that will end up in an odd place
+    , Ord)

--- a/data/fourmolu/sort-derived-classes/output-False.hs
+++ b/data/fourmolu/sort-derived-classes/output-False.hs
@@ -1,0 +1,19 @@
+module Main where
+
+data A
+    deriving (Show, Eq, Ord)
+
+newtype B = B Int
+    deriving newtype (Num)
+    deriving stock (Show, Eq, Generic)
+    deriving (Semigroup, Monoid) via (Generically B)
+    deriving stock (Ord, Generic)
+    deriving (ToJSON)
+
+data C
+    deriving
+        ( Show
+        , Eq
+        , -- A comment that will end up in an odd place
+          Ord
+        )

--- a/data/fourmolu/sort-derived-classes/output-True.hs
+++ b/data/fourmolu/sort-derived-classes/output-True.hs
@@ -1,0 +1,19 @@
+module Main where
+
+data A
+    deriving (Eq, Ord, Show)
+
+newtype B = B Int
+    deriving newtype (Num)
+    deriving stock (Eq, Generic, Show)
+    deriving (Monoid, Semigroup) via (Generically B)
+    deriving stock (Generic, Ord)
+    deriving (ToJSON)
+
+data C
+    deriving
+        ( Eq
+        , -- A comment that will end up in an odd place
+          Ord
+        , Show
+        )

--- a/data/fourmolu/sort-deriving-clauses/input.hs
+++ b/data/fourmolu/sort-deriving-clauses/input.hs
@@ -1,0 +1,12 @@
+module Main where
+
+newtype A = A Int
+  deriving newtype (Num)
+  deriving stock (Show, Eq)
+  deriving stock (Ord, Generic)
+  deriving (ToJSON)
+
+data B 
+  -- A comment that will end up in an odd place
+  deriving stock (Show)
+  deriving (Eq)

--- a/data/fourmolu/sort-deriving-clauses/output-False.hs
+++ b/data/fourmolu/sort-deriving-clauses/output-False.hs
@@ -1,0 +1,12 @@
+module Main where
+
+newtype A = A Int
+    deriving newtype (Num)
+    deriving stock (Show, Eq)
+    deriving stock (Ord, Generic)
+    deriving (ToJSON)
+
+data B
+    -- A comment that will end up in an odd place
+    deriving stock (Show)
+    deriving (Eq)

--- a/data/fourmolu/sort-deriving-clauses/output-True.hs
+++ b/data/fourmolu/sort-deriving-clauses/output-True.hs
@@ -1,0 +1,13 @@
+module Main where
+
+newtype A = A Int
+    deriving (ToJSON)
+    deriving stock (Show, Eq)
+    deriving stock (Ord, Generic)
+    deriving newtype (Num)
+
+data B
+    -- A comment that will end up in an odd place
+
+    deriving (Eq)
+    deriving stock (Show)

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -22,3 +22,5 @@ reexports: []
 import-grouping: legacy
 local-modules: []
 sort-constraints: false
+sort-derived-classes: false
+sort-deriving-clauses: false

--- a/src/Ormolu/Config/Gen.hs
+++ b/src/Ormolu/Config/Gen.hs
@@ -79,6 +79,10 @@ data PrinterOpts f =
       poImportGrouping :: f ImportGrouping
     , -- | Whether to sort constraints
       poSortConstraints :: f Bool
+    , -- | Whether to sort derived classes
+      poSortDerivedClasses :: f Bool
+    , -- | Whether to sort deriving clauses
+      poSortDerivingClauses :: f Bool
     }
   deriving (Generic)
 
@@ -103,6 +107,8 @@ emptyPrinterOpts =
     , poRespectful = Nothing
     , poImportGrouping = Nothing
     , poSortConstraints = Nothing
+    , poSortDerivedClasses = Nothing
+    , poSortDerivingClauses = Nothing
     }
 
 defaultPrinterOpts :: PrinterOpts Identity
@@ -126,6 +132,8 @@ defaultPrinterOpts =
     , poRespectful = pure True
     , poImportGrouping = pure ImportGroupLegacy
     , poSortConstraints = pure False
+    , poSortDerivedClasses = pure False
+    , poSortDerivingClauses = pure False
     }
 
 -- | Fill the field values that are 'Nothing' in the first argument
@@ -156,6 +164,8 @@ fillMissingPrinterOpts p1 p2 =
     , poRespectful = maybe (poRespectful p2) pure (poRespectful p1)
     , poImportGrouping = maybe (poImportGrouping p2) pure (poImportGrouping p1)
     , poSortConstraints = maybe (poSortConstraints p2) pure (poSortConstraints p1)
+    , poSortDerivedClasses = maybe (poSortDerivedClasses p2) pure (poSortDerivedClasses p1)
+    , poSortDerivingClauses = maybe (poSortDerivingClauses p2) pure (poSortDerivingClauses p1)
     }
 
 parsePrinterOptsCLI ::
@@ -236,6 +246,14 @@ parsePrinterOptsCLI f =
       "sort-constraints"
       "Whether to sort constraints (default: false)"
       "BOOL"
+    <*> f
+      "sort-derived-classes"
+      "Whether to sort derived classes (default: false)"
+      "BOOL"
+    <*> f
+      "sort-deriving-clauses"
+      "Whether to sort deriving clauses (default: false)"
+      "BOOL"
 
 parsePrinterOptsJSON ::
   Applicative f =>
@@ -261,6 +279,8 @@ parsePrinterOptsJSON f =
     <*> f "respectful"
     <*> f "import-grouping"
     <*> f "sort-constraints"
+    <*> f "sort-derived-classes"
+    <*> f "sort-deriving-clauses"
 
 {---------- PrinterOpts field types ----------}
 
@@ -654,4 +674,10 @@ defaultPrinterOptsYaml =
     , ""
     , "# Whether to sort constraints"
     , "sort-constraints: false"
+    , ""
+    , "# Whether to sort derived classes"
+    , "sort-derived-classes: false"
+    , ""
+    , "# Whether to sort deriving clauses"
+    , "sort-deriving-clauses: false"
     ]

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -327,6 +327,24 @@ spec =
           showTestCase = show,
           testCaseSuffix = suffix1,
           checkIdempotence = True
+        },
+      TestGroup
+        { label = "sort-derived-classes",
+          isMulti = False,
+          testCases = allOptions,
+          updateConfig = \sortDerivedClasses opts -> opts {poSortDerivedClasses = pure sortDerivedClasses},
+          showTestCase = show,
+          testCaseSuffix = suffix1,
+          checkIdempotence = True
+        },
+      TestGroup
+        { label = "sort-deriving-clauses",
+          isMulti = False,
+          testCases = allOptions,
+          updateConfig = \sortDerivingClauses opts -> opts {poSortDerivingClauses = pure sortDerivingClauses},
+          showTestCase = show,
+          testCaseSuffix = suffix1,
+          checkIdempotence = True
         }
     ]
 

--- a/web/site/pages/config/sort-derived-classes.md
+++ b/web/site/pages/config/sort-derived-classes.md
@@ -1,0 +1,24 @@
+# `sort-derived-classes`
+
+$info$
+
+This option determines whether classes in deriving clauses are sorted.
+
+Note that using this option may cause comments inside deriving clauses to be misplaced.
+
+## Examples
+
+```fourmolu-example-input
+data A
+  deriving stock (Show, Eq, Ord, Generic)
+```
+```fourmolu-example-tab
+With sorting
+{ "sort-derived-classes": true }
+```
+```fourmolu-example-tab
+Without sorting
+{ "sort-derived-classes": false }
+```
+
+For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/sort-derived-classes).

--- a/web/site/pages/config/sort-deriving-clauses.md
+++ b/web/site/pages/config/sort-deriving-clauses.md
@@ -1,0 +1,26 @@
+# `sort-deriving-clauses`
+
+$info$
+
+This option determines whether to sort deriving clauses.
+
+Note that using this option may cause comments between deriving clauses to be misplaced.
+
+## Examples
+
+```fourmolu-example-input
+newtype A = A Int
+  deriving newtype (Num)
+  deriving (ToJSON)
+  deriving stock (Show, Eq, Ord, Generic)
+```
+```fourmolu-example-tab
+With sorting
+{ "sort-deriving-clauses": true }
+```
+```fourmolu-example-tab
+Without sorting
+{ "sort-deriving-clauses": false }
+```
+
+For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/sort-deriving-clauses).


### PR DESCRIPTION
This adds two configuration options for sorting a) types in deriving clauses, and b) deriving clauses themselves.

Fixes https://github.com/tweag/ormolu/issues/968