### PR TITLE
Remove unused `getDotOrmoluForSourceFile` and simplify call sites

### DIFF
--- a/src/Ormolu/Utils/Fixity.hs
+++ b/src/Ormolu/Utils/Fixity.hs
@@ -1,66 +1,19 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Ormolu.Utils.Fixity
-  ( getDotOrmoluForSourceFile,
-    parseFixityDeclarationStr,
+  ( parseFixityDeclarationStr,
     parseModuleReexportDeclarationStr,
   )
 where
 
-import Control.Exception (throwIO)
-import Control.Monad.IO.Class
 import Data.Bifunctor (first)
-import Data.IORef
 import Data.List.NonEmpty (NonEmpty)
-import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
-import Data.Text.IO.Utf8 qualified as T.Utf8
 import Distribution.ModuleName (ModuleName)
 import Distribution.Types.PackageName (PackageName)
-import Ormolu.Exception
 import Ormolu.Fixity
 import Ormolu.Fixity.Parser
-import Ormolu.Utils.IO (findClosestFileSatisfying, withIORefCache)
-import System.Directory
-import System.IO.Unsafe (unsafePerformIO)
 import Text.Megaparsec (errorBundlePretty)
-
--- | Attempt to locate and parse an @.ormolu@ file. If it does not exist,
--- default fixity map and module reexports are returned. This function
--- maintains a cache of fixity overrides and module re-exports where cabal
--- file paths act as keys.
-getDotOrmoluForSourceFile ::
-  (MonadIO m) =>
-  -- | 'CabalInfo' already obtained for this source file
-  FilePath ->
-  m (FixityOverrides, ModuleReexports)
-getDotOrmoluForSourceFile sourceFile =
-  liftIO (findDotOrmoluFile sourceFile) >>= \case
-    Just dotOrmoluFile -> liftIO $ withIORefCache cacheRef dotOrmoluFile $ do
-      dotOrmoluRelative <- makeRelativeToCurrentDirectory dotOrmoluFile
-      contents <- T.Utf8.readFile dotOrmoluFile
-      case parseDotOrmolu dotOrmoluRelative contents of
-        Left errorBundle ->
-          throwIO (OrmoluFixityOverridesParseError errorBundle)
-        Right x -> return x
-    Nothing -> return (defaultFixityOverrides, defaultModuleReexports)
-
--- | Find the path to an appropriate @.ormolu@ file for a Haskell source
--- file, if available.
-findDotOrmoluFile ::
-  (MonadIO m) =>
-  -- | Path to a Haskell source file
-  FilePath ->
-  -- | Absolute path to the closest @.ormolu@ file, if available
-  m (Maybe FilePath)
-findDotOrmoluFile = findClosestFileSatisfying $ \x ->
-  x == ".ormolu"
-
--- | Cache ref that maps names of @.ormolu@ files to their contents.
-cacheRef :: IORef (Map FilePath (FixityOverrides, ModuleReexports))
-cacheRef = unsafePerformIO (newIORef Map.empty)
-{-# NOINLINE cacheRef #-}
 
 -- | A wrapper around 'parseFixityDeclaration' for parsing individual fixity
 -- definitions.


### PR DESCRIPTION
I noticed while poking around that this function is actually dead, because we don't use `.ormolu` files, since that config goes in `fourmolu.yaml` instead. So, instead of just effectively hardcoding `--no-dot-ormolu`, I've removed the field internally, which opens up a cascade of simplifications. I haven't thought too heavily about what any of these small refactors mean. I just kept simplifying by equational reasoning, only getting slightly tricky around `refineConfig`, which I'm still reasonably sure is correct.

Having done it, I'm actually unsure whether this is a good idea. Although code is mostly just deleted, it still slightly increases potential for merge conflicts with Ormolu, without much real benefit.