### PR TITLE
Fix wasm build

### DIFF
--- a/web/fourmolu-wasm/cbits/init.c
+++ b/web/fourmolu-wasm/cbits/init.c
@@ -1,3 +1,4 @@
+#include "string.h"
 #include "Rts.h"
 
 #include "Main_stub.h"


### PR DESCRIPTION
Fix error in WASM build:
```
cbits/init.c:12:5: error:
     error: call to undeclared library function 'memset' with type 'void *(void *, int, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
       12 |     memset(start, 0, (size_t)end - (size_t)start);
          |     ^
   |
12 |     memset(start, 0, (size_t)end - (size_t)start);
   |     ^

cbits/init.c:12:5: error:
     note: include the header <string.h> or explicitly provide a declaration for 'memset'
   |
12 |     memset(start, 0, (size_t)end - (size_t)start);
   |     ^
1 error generated.
`wasm32-wasi-clang' failed in phase `C Compiler'. (Exit code: 1)
Error: [Cabal-7125]
Failed to build exe:fourmolu-wasm from fourmolu-wasm-0.
```
Ormolu doesn't seem to do anything special to handle this, so I suspect Ormolu's Nix derivation pins the version of GCC or something.