### PR TITLE
Release 0.17.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         ghc_version:
           - '9.6'
-          - '9.8'
+          - '9.8.2' # https://gitlab.haskell.org/ghc/ghc/-/issues/25576
           - '9.10'
 
     name: 'cabal_test: ghc-${{ matrix.ghc_version }}'

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  GHC_VERSION: '9.10'
+
 jobs:
   build_wasm:
     runs-on: ubuntu-latest
@@ -23,12 +26,11 @@ jobs:
           echo ~/.cabal/bin >> "${GITHUB_PATH}"
       -
         name: Install wasm32-wasi-ghc
-        # TODO: bump to 9.10: https://github.com/digital-asset/ghc-lib/issues/563#issuecomment-2453777392
         run: |
           cd "$(mktemp -d)"
           curl -L https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/archive/master/ghc-wasm-meta-master.tar.gz \
             | tar xz --strip-components=1
-          FLAVOUR=9.8 ./setup.sh
+          FLAVOUR=${GHC_VERSION} ./setup.sh
           ~/.ghc-wasm/add_to_github_path.sh
       -
         run: wasm32-wasi-cabal update
@@ -78,6 +80,10 @@ jobs:
     steps:
       -
         uses: actions/checkout@v4
+      -
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ env.GHC_VERSION }}
       -
         run: cabal update
       -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Fourmolu 0.17.0.0
+
+* Add new `import-grouping` option to group imports with grouping rules specified in configuration ([#403](https://github.com/fourmolu/fourmolu/pull/403))
+
+* Add new `sort-constraints` option to sort constraints alphabetically ([#433](https://github.com/fourmolu/fourmolu/pull/433))
+
+* Add new `sort-derived-classes` option to sort classes in deriving clauses ([#434](https://github.com/fourmolu/fourmolu/pull/434))
+
+* Add new `sort-derived-clauses` option to sort classes deriving clauses ([#434](https://github.com/fourmolu/fourmolu/pull/434))
+
+* Add new `trailing-section-operators` option to disable trailing "section" operators (those that are `infixr 0`, such as `$`) ([#444](https://github.com/fourmolu/fourmolu/pull/444))
+
+* Fix issue where `single-constraint-parens: never` would drop parentheses around implicit parameters ([#446](https://github.com/fourmolu/fourmolu/issues/446))
+
+* Fix indentation for parenthesized expressions that start off the indentation column ([#428](https://github.com/fourmolu/fourmolu/issues/428))
+
+* Allow multiline comments in indented contexts ([#65](https://github.com/fourmolu/fourmolu/issues/65))
+
+
 ## Fourmolu 0.16.2.0
 
 ### Upstream changes:

--- a/changelog.d/implicit-params-parens.md
+++ b/changelog.d/implicit-params-parens.md
@@ -1,1 +1,0 @@
-* Fix issue where `single-constraint-parens: never` would drop parentheses around implicit parameters ([#446](https://github.com/fourmolu/fourmolu/issues/446))

--- a/changelog.d/import-grouping.md
+++ b/changelog.d/import-grouping.md
@@ -1,3 +1,0 @@
-# `import-grouping`
-
-This adds a configuration entry to organize imports into groups. How the import declarations are regrouped is determined by the configured rules. The developer can choose between a predefined preset, or create their own rules.

--- a/changelog.d/indent.md
+++ b/changelog.d/indent.md
@@ -1,1 +1,0 @@
-* Fix indentation for parenthesized expressions that start off the indentation column ([#428](https://github.com/fourmolu/fourmolu/issues/428))

--- a/changelog.d/multiline-comments-indented.md
+++ b/changelog.d/multiline-comments-indented.md
@@ -1,1 +1,0 @@
-* Allow multiline comments in indented contexts ([#65](https://github.com/fourmolu/fourmolu/issues/65))

--- a/changelog.d/sort-constraints.md
+++ b/changelog.d/sort-constraints.md
@@ -1,3 +1,0 @@
-# `sort-constraints`
-
-This adds a configuration to sort constraints. The constraints are sorted in alphabetical order.

--- a/changelog.d/sort-derived-classes.md
+++ b/changelog.d/sort-derived-classes.md
@@ -1,3 +1,0 @@
-# `sort-derived-classes`
-
-This adds a configuration option to sort the classes in deriving clauses.

--- a/changelog.d/sort-deriving-clauses.md
+++ b/changelog.d/sort-deriving-clauses.md
@@ -1,3 +1,0 @@
-# `sort-deriving-clauses`
-
-This adds a configuration option to sort deriving clauses.

--- a/changelog.d/trailing-section-operators.md
+++ b/changelog.d/trailing-section-operators.md
@@ -1,3 +1,0 @@
-# `trailing-section-operators`
-
-This adds a configuration to disable trailing "section" operators (those that are `infixr 0`, such as `$`) ([#444](https://github.com/fourmolu/fourmolu/pull/444))

--- a/config/FourmoluConfig/ConfigData.hs
+++ b/config/FourmoluConfig/ConfigData.hs
@@ -236,7 +236,7 @@ allOptions =
         type_ = "ImportGrouping",
         default_ = HsExpr "ImportGroupLegacy",
         ormolu = HsExpr "ImportGroupLegacy",
-        sinceVersion = Nothing,
+        sinceVersion = Just "0.17.0.0",
         cliOverrides = emptyOverrides
       },
     Option
@@ -246,7 +246,7 @@ allOptions =
         type_ = "[String]",
         default_ = HsList [],
         ormolu = HsList [],
-        sinceVersion = Nothing,
+        sinceVersion = Just "0.17.0.0",
         cliOverrides = emptyOverrides
       },
     Option
@@ -256,7 +256,7 @@ allOptions =
         type_ = "Bool",
         default_ = HsBool False,
         ormolu = HsBool False,
-        sinceVersion = Nothing,
+        sinceVersion = Just "0.17.0.0",
         cliOverrides = emptyOverrides
       },
     Option
@@ -266,7 +266,7 @@ allOptions =
         type_ = "Bool",
         default_ = HsBool False,
         ormolu = HsBool False,
-        sinceVersion = Nothing,
+        sinceVersion = Just "0.17.0.0",
         cliOverrides = emptyOverrides
       },
     Option
@@ -276,7 +276,7 @@ allOptions =
         type_ = "Bool",
         default_ = HsBool False,
         ormolu = HsBool False,
-        sinceVersion = Nothing,
+        sinceVersion = Just "0.17.0.0",
         cliOverrides = emptyOverrides
       },
     Option
@@ -286,7 +286,7 @@ allOptions =
         type_ = "Bool",
         default_ = HsBool True,
         ormolu = HsBool True,
-        sinceVersion = Nothing,
+        sinceVersion = Just "0.17.0.0",
         cliOverrides = emptyOverrides
       }
   ]

--- a/config/FourmoluConfig/ConfigData.hs
+++ b/config/FourmoluConfig/ConfigData.hs
@@ -100,6 +100,16 @@ allOptions =
         cliOverrides = emptyOverrides
       },
     Option
+      { name = "import-grouping",
+        fieldName = Just "poImportGrouping",
+        description = "Rules for grouping import declarations",
+        type_ = "ImportGrouping",
+        default_ = HsExpr "ImportGroupLegacy",
+        ormolu = HsExpr "ImportGroupLegacy",
+        sinceVersion = Just "0.17.0.0",
+        cliOverrides = emptyOverrides
+      },
+    Option
       { name = "indent-wheres",
         fieldName = Just "poIndentWheres",
         description = "Whether to full-indent or half-indent 'where' bindings past the preceding body",
@@ -190,6 +200,46 @@ allOptions =
         cliOverrides = emptyOverrides
       },
     Option
+      { name = "sort-constraints",
+        fieldName = Just "poSortConstraints",
+        description = "Whether to sort constraints",
+        type_ = "Bool",
+        default_ = HsBool False,
+        ormolu = HsBool False,
+        sinceVersion = Just "0.17.0.0",
+        cliOverrides = emptyOverrides
+      },
+    Option
+      { name = "sort-derived-classes",
+        fieldName = Just "poSortDerivedClasses",
+        description = "Whether to sort derived classes",
+        type_ = "Bool",
+        default_ = HsBool False,
+        ormolu = HsBool False,
+        sinceVersion = Just "0.17.0.0",
+        cliOverrides = emptyOverrides
+      },
+    Option
+      { name = "sort-deriving-clauses",
+        fieldName = Just "poSortDerivingClauses",
+        description = "Whether to sort deriving clauses",
+        type_ = "Bool",
+        default_ = HsBool False,
+        ormolu = HsBool False,
+        sinceVersion = Just "0.17.0.0",
+        cliOverrides = emptyOverrides
+      },
+    Option
+      { name = "trailing-section-operators",
+        fieldName = Just "poTrailingSectionOperators",
+        description = "Whether to place section operators (those that are infixr 0, such as $) in trailing position, continuing the expression indented below",
+        type_ = "Bool",
+        default_ = HsBool True,
+        ormolu = HsBool True,
+        sinceVersion = Just "0.17.0.0",
+        cliOverrides = emptyOverrides
+      },
+    Option
       { name = "unicode",
         fieldName = Just "poUnicode",
         description = "Output Unicode syntax",
@@ -230,62 +280,12 @@ allOptions =
         cliOverrides = emptyOverrides
       },
     Option
-      { name = "import-grouping",
-        fieldName = Just "poImportGrouping",
-        description = "Rules for grouping import declarations",
-        type_ = "ImportGrouping",
-        default_ = HsExpr "ImportGroupLegacy",
-        ormolu = HsExpr "ImportGroupLegacy",
-        sinceVersion = Just "0.17.0.0",
-        cliOverrides = emptyOverrides
-      },
-    Option
       { name = "local-modules",
         fieldName = Nothing,
         description = "Modules defined by the current Cabal package for import grouping",
         type_ = "[String]",
         default_ = HsList [],
         ormolu = HsList [],
-        sinceVersion = Just "0.17.0.0",
-        cliOverrides = emptyOverrides
-      },
-    Option
-      { name = "sort-constraints",
-        fieldName = Just "poSortConstraints",
-        description = "Whether to sort constraints",
-        type_ = "Bool",
-        default_ = HsBool False,
-        ormolu = HsBool False,
-        sinceVersion = Just "0.17.0.0",
-        cliOverrides = emptyOverrides
-      },
-    Option
-      { name = "sort-derived-classes",
-        fieldName = Just "poSortDerivedClasses",
-        description = "Whether to sort derived classes",
-        type_ = "Bool",
-        default_ = HsBool False,
-        ormolu = HsBool False,
-        sinceVersion = Just "0.17.0.0",
-        cliOverrides = emptyOverrides
-      },
-    Option
-      { name = "sort-deriving-clauses",
-        fieldName = Just "poSortDerivingClauses",
-        description = "Whether to sort deriving clauses",
-        type_ = "Bool",
-        default_ = HsBool False,
-        ormolu = HsBool False,
-        sinceVersion = Just "0.17.0.0",
-        cliOverrides = emptyOverrides
-      },
-    Option
-      { name = "trailing-section-operators",
-        fieldName = Just "poTrailingSectionOperators",
-        description = "Whether to place section operators (those that are infixr 0, such as $) in trailing position, continuing the expression indented below",
-        type_ = "Bool",
-        default_ = HsBool True,
-        ormolu = HsBool True,
         sinceVersion = Just "0.17.0.0",
         cliOverrides = emptyOverrides
       }

--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               fourmolu
-version:            0.16.2.0
+version:            0.17.0.0
 license:            BSD-3-Clause
 license-file:       LICENSE.md
 maintainer:

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -6,6 +6,7 @@ column-limit: none
 function-arrows: trailing
 comma-style: trailing
 import-export-style: trailing
+import-grouping: legacy
 indent-wheres: true
 record-brace-space: true
 newlines-between-decls: 1
@@ -15,13 +16,12 @@ let-style: inline
 in-style: right-align
 single-constraint-parens: always
 single-deriving-parens: always
-unicode: never
-respectful: false
-fixities: []
-reexports: []
-import-grouping: legacy
-local-modules: []
 sort-constraints: false
 sort-derived-classes: false
 sort-deriving-clauses: false
 trailing-section-operators: true
+unicode: never
+respectful: false
+fixities: []
+reexports: []
+local-modules: []

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -125,6 +125,80 @@ spec =
           checkIdempotence = True
         },
       TestGroup
+        { label = "import-grouping",
+          isMulti = False,
+          testCases =
+            [ ImportGroupPreserve,
+              ImportGroupSingle,
+              ImportGroupByQualified,
+              ImportGroupByScope,
+              ImportGroupByScopeThenQualified,
+              ImportGroupCustom . NonEmpty.fromList $
+                [ ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
+                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                                igrPriority = defaultImportRulePriority
+                              }
+                          ]
+                    },
+                  ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchAllModules,
+                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                                igrPriority = ImportRulePriority 100
+                              }
+                          ]
+                    },
+                  ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchGlob (mkGlob "SomeInternal.**"),
+                                igrQualifiedMatcher = MatchQualifiedOnly,
+                                igrPriority = defaultImportRulePriority
+                              },
+                            ImportGroupRule
+                              { igrModuleMatcher = MatchGlob (mkGlob "Unknown.**"),
+                                igrQualifiedMatcher = MatchUnqualifiedOnly,
+                                igrPriority = defaultImportRulePriority
+                              }
+                          ]
+                    },
+                  ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchLocalModules,
+                                igrQualifiedMatcher = MatchUnqualifiedOnly,
+                                igrPriority = defaultImportRulePriority
+                              },
+                            ImportGroupRule
+                              { igrModuleMatcher = MatchAllModules,
+                                igrQualifiedMatcher = MatchQualifiedOnly,
+                                igrPriority = defaultImportRulePriority
+                              }
+                          ]
+                    }
+                ]
+            ],
+          updateConfig = \igs opts ->
+            opts
+              { poImportGrouping = pure igs
+              },
+          showTestCase = showStrategy,
+          testCaseSuffix = \igs -> suffixWith [showStrategy igs],
+          checkIdempotence = True
+        },
+      TestGroup
         { label = "record-brace-space",
           isMulti = False,
           testCases = allOptions,
@@ -206,113 +280,6 @@ spec =
           checkIdempotence = True
         },
       TestGroup
-        { label = "unicode-syntax",
-          isMulti = False,
-          testCases = allOptions,
-          updateConfig = \unicodePreference options -> options {poUnicode = pure unicodePreference},
-          showTestCase = show,
-          testCaseSuffix = suffix1,
-          checkIdempotence = True
-        },
-      TestGroup
-        { label = "respectful",
-          isMulti = False,
-          testCases = allOptions,
-          updateConfig = \respectful opts -> opts {poRespectful = pure respectful},
-          showTestCase = show,
-          testCaseSuffix = suffix1,
-          checkIdempotence = True
-        },
-      TestGroup
-        { label = "respectful-module-where",
-          isMulti = True,
-          testCases = (,) <$> allOptions <*> allOptions,
-          updateConfig = \(respectful, importExportStyle) opts ->
-            opts
-              { poRespectful = pure respectful,
-                poImportExportStyle = pure importExportStyle
-              },
-          showTestCase = \(respectful, importExportStyle) ->
-            (if respectful then "respectful" else "not respectful") ++ " + " ++ show importExportStyle,
-          testCaseSuffix = \(respectful, importExportStyle) ->
-            suffixWith ["respectful=" ++ show respectful, show importExportStyle],
-          checkIdempotence = True
-        },
-      TestGroup
-        { label = "import-grouping",
-          isMulti = False,
-          testCases =
-            [ ImportGroupPreserve,
-              ImportGroupSingle,
-              ImportGroupByQualified,
-              ImportGroupByScope,
-              ImportGroupByScopeThenQualified,
-              ImportGroupCustom . NonEmpty.fromList $
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    },
-                  ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = ImportRulePriority 100
-                              }
-                          ]
-                    },
-                  ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "SomeInternal.**"),
-                                igrQualifiedMatcher = MatchQualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              },
-                            ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Unknown.**"),
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    },
-                  ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchLocalModules,
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              },
-                            ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrQualifiedMatcher = MatchQualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-            ],
-          updateConfig = \igs opts ->
-            opts
-              { poImportGrouping = pure igs
-              },
-          showTestCase = showStrategy,
-          testCaseSuffix = \igs -> suffixWith [showStrategy igs],
-          checkIdempotence = True
-        },
-      TestGroup
         { label = "sort-constraints",
           isMulti = False,
           testCases = allOptions,
@@ -346,6 +313,39 @@ spec =
           updateConfig = \trailingSectionOperators opts -> opts {poTrailingSectionOperators = pure trailingSectionOperators},
           showTestCase = show,
           testCaseSuffix = suffix1,
+          checkIdempotence = True
+        },
+      TestGroup
+        { label = "unicode-syntax",
+          isMulti = False,
+          testCases = allOptions,
+          updateConfig = \unicodePreference options -> options {poUnicode = pure unicodePreference},
+          showTestCase = show,
+          testCaseSuffix = suffix1,
+          checkIdempotence = True
+        },
+      TestGroup
+        { label = "respectful",
+          isMulti = False,
+          testCases = allOptions,
+          updateConfig = \respectful opts -> opts {poRespectful = pure respectful},
+          showTestCase = show,
+          testCaseSuffix = suffix1,
+          checkIdempotence = True
+        },
+      TestGroup
+        { label = "respectful-module-where",
+          isMulti = True,
+          testCases = (,) <$> allOptions <*> allOptions,
+          updateConfig = \(respectful, importExportStyle) opts ->
+            opts
+              { poRespectful = pure respectful,
+                poImportExportStyle = pure importExportStyle
+              },
+          showTestCase = \(respectful, importExportStyle) ->
+            (if respectful then "respectful" else "not respectful") ++ " + " ++ show importExportStyle,
+          testCaseSuffix = \(respectful, importExportStyle) ->
+            suffixWith ["respectful=" ++ show respectful, show importExportStyle],
           checkIdempotence = True
         }
     ]

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ This directory contains files that are served at `fourmolu.github.io`.
 
 ### Build locally
 
-1. Follow the steps at https://gitlab.haskell.org/ghc/ghc-wasm-meta to install GHC with the WASM backend
+1. Follow the steps at https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta to install GHC with the WASM backend
 
 1. Install [Wizer](https://github.com/bytecodealliance/wizer)
 

--- a/web/fourmolu-wasm/cabal.project
+++ b/web/fourmolu-wasm/cabal.project
@@ -1,5 +1,9 @@
 packages: . ../..
 
+allow-newer:
+  -- https://github.com/haskell/time/issues/266
+  , time-compat:time
+
 package fourmolu
   flags: -internal-bundle-fixities
 

--- a/web/fourmolu-wasm/cbits/init.c
+++ b/web/fourmolu-wasm/cbits/init.c
@@ -1,18 +1,6 @@
-#include "string.h"
 #include "Rts.h"
 
 #include "Main_stub.h"
-
-void malloc_inspect_all(void (*handler)(void *start, void *end,
-                                        size_t used_bytes, void *callback_arg),
-                        void *arg);
-
-static void malloc_inspect_all_handler(void *start, void *end,
-                                       size_t used_bytes, void *callback_arg) {
-  if (used_bytes == 0) {
-    memset(start, 0, (size_t)end - (size_t)start);
-  }
-}
 
 __attribute__((export_name("wizer.initialize"))) void __wizer_initialize(void) {
   char *args[] = {
@@ -28,6 +16,4 @@ __attribute__((export_name("wizer.initialize"))) void __wizer_initialize(void) {
   hs_perform_gc();
   hs_perform_gc();
   rts_clearMemory();
-  malloc_inspect_all(malloc_inspect_all_handler, NULL);
-  memset(0, 0, (size_t)__builtin_frame_address(0));
 }

--- a/web/site/fourmolu-web.cabal
+++ b/web/site/fourmolu-web.cabal
@@ -13,6 +13,7 @@ executable fourmolu-web
         , aeson
         , base
         , bytestring
+        , Cabal-syntax
         , cmark-gfm-simple
         , containers
         , filepath

--- a/web/site/pages/config/sort-constraints.md
+++ b/web/site/pages/config/sort-constraints.md
@@ -2,7 +2,7 @@
 
 $info$
 
-This option determines whether or not to sort constraints. 
+This option determines whether constraints should be sorted alphabetically or left alone.
 
 The sorting applies wherever we can determine that a constraint tuple is in fact a constraint tuple type (and not a normal tuple type).
 In some situations we cannot determine this and so the constraints are not sorted.
@@ -15,12 +15,12 @@ Note that using this option may result in comments inside constraints being move
 f :: (Show a, Eq a) => a
 ```
 ```fourmolu-example-tab
-With sorting
-{ "sort-constraints": true }
-```
-```fourmolu-example-tab
 Without sorting
 { "sort-constraints": false }
+```
+```fourmolu-example-tab
+With sorting
+{ "sort-constraints": true }
 ```
 
 For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/sort-constraints).

--- a/web/site/pages/config/sort-derived-classes.md
+++ b/web/site/pages/config/sort-derived-classes.md
@@ -2,7 +2,7 @@
 
 $info$
 
-This option determines whether classes in deriving clauses are sorted.
+This option determines whether classes in deriving clauses should be sorted alphabetically or left alone.
 
 Note that using this option may cause comments inside deriving clauses to be misplaced.
 
@@ -13,12 +13,12 @@ data A
   deriving stock (Show, Eq, Ord, Generic)
 ```
 ```fourmolu-example-tab
-With sorting
-{ "sort-derived-classes": true }
-```
-```fourmolu-example-tab
 Without sorting
 { "sort-derived-classes": false }
+```
+```fourmolu-example-tab
+With sorting
+{ "sort-derived-classes": true }
 ```
 
 For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/sort-derived-classes).

--- a/web/site/pages/config/sort-deriving-clauses.md
+++ b/web/site/pages/config/sort-deriving-clauses.md
@@ -2,7 +2,7 @@
 
 $info$
 
-This option determines whether to sort deriving clauses.
+This option determines whether deriving clauses should be sorted alphabetically or left alone.
 
 Note that using this option may cause comments between deriving clauses to be misplaced.
 
@@ -15,12 +15,12 @@ newtype A = A Int
   deriving stock (Show, Eq, Ord, Generic)
 ```
 ```fourmolu-example-tab
-With sorting
-{ "sort-deriving-clauses": true }
-```
-```fourmolu-example-tab
 Without sorting
 { "sort-deriving-clauses": false }
+```
+```fourmolu-example-tab
+With sorting
+{ "sort-deriving-clauses": true }
 ```
 
 For more examples, see the [test files](https://github.com/fourmolu/fourmolu/tree/main/data/fourmolu/sort-deriving-clauses).

--- a/web/site/pages/config/trailing-section-operators.md
+++ b/web/site/pages/config/trailing-section-operators.md
@@ -2,8 +2,6 @@
 
 $info$
 
-This option determines if "section" operators (those that are `infixr 0`, such as `$$`) are left in a trailing position or not.
-
 ## Examples
 
 ```fourmolu-example-input

--- a/web/site/site.hs
+++ b/web/site/site.hs
@@ -17,6 +17,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Version (showVersion)
+import Distribution.Types.PackageName (mkPackageName)
 import FourmoluConfig.ConfigData qualified as ConfigData
 import FourmoluConfig.GenerateUtils (fieldTypesMap, getOptionSchema, hs2yaml)
 import GHC.SyntaxHighlighter.Themed.HighlightJS qualified as HighlightJS
@@ -276,6 +277,7 @@ replaceFourmoluExamples =
             let config =
                   Fourmolu.defaultConfig
                     { Fourmolu.cfgPrinterOpts = Fourmolu.resolvePrinterOpts [printerOpts],
+                      Fourmolu.cfgDependencies = S.fromList [mkPackageName "base"],
                       Fourmolu.cfgLocalModules =
                         S.fromList $
                           fromString

--- a/web/site/static/style.css
+++ b/web/site/static/style.css
@@ -1,10 +1,16 @@
 main {
     padding: 0 5em;
+
+    /*
+    When in a grid inside .sidebar-container, prevent expanding
+    outside the grid
+    https://stackoverflow.com/a/43312314
+    */
+    min-width: 0;
 }
 
 .sidebar-container {
     display: grid;
-    grid-auto-flow: column;
     grid-template-columns: max-content 1fr;
 }
 


### PR DESCRIPTION
TODO:
- [x] With GHC 9.8.4: multiple definition of 'ghc_unique_counter64' (https://gitlab.haskell.org/ghc/ghc/-/issues/25576)
- [x] With GHC 9.10.1.20241209: call to undeclared function tzset (https://github.com/haskell/time/issues/266)
- [x] Make sure WASM didn't grow too big, due to removing memset
    * WASM was 7.42 MB before this change (https://github.com/fourmolu/fourmolu/actions/runs/12236298554)
    * WASM is now 7.45 MB, which isn't a big regression ✅ 