### PR TITLE
Add `import-list` import grouping option

### DIFF
--- a/changelog.d/add-import-list-option.md
+++ b/changelog.d/add-import-list-option.md
@@ -1,1 +1,1 @@
-- Add the `import-list` option for import grouping.
+- Add the `import-list` option for import grouping ([pull request 522](https://github.com/fourmolu/fourmolu/pull/522) for [issue 519](https://github.com/fourmolu/fourmolu/issues/519)).

--- a/changelog.d/add-import-list-option.md
+++ b/changelog.d/add-import-list-option.md
@@ -1,0 +1,1 @@
+- Add the `import-list` option for import grouping.

--- a/data/fourmolu/import-grouping/input.hs
+++ b/data/fourmolu/import-grouping/input.hs
@@ -1,13 +1,16 @@
 module Main where
 
+import Data.Either
 import Data.Text (Text)
 import Data.Maybe (maybe)
 
 import qualified Data.Text
 import Control.Monad (Monad (..))
+import Data.Functor
 
 import qualified System.IO as SIO
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
 import qualified SomeInternal.Module2 as Mod2
 import Text.Printf (printf)
 import qualified SomeModule
+import SomeInternal.Module2

--- a/data/fourmolu/import-grouping/output-by_qualified.hs
+++ b/data/fourmolu/import-grouping/output-by_qualified.hs
@@ -1,9 +1,12 @@
 module Main where
 
 import Control.Monad (Monad (..))
+import Data.Either
+import Data.Functor
 import Data.Maybe (maybe)
 import Data.Text (Text)
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
+import SomeInternal.Module2
 import Text.Printf (printf)
 
 import qualified Data.Text

--- a/data/fourmolu/import-grouping/output-by_scope.hs
+++ b/data/fourmolu/import-grouping/output-by_scope.hs
@@ -1,6 +1,8 @@
 module Main where
 
 import Control.Monad (Monad (..))
+import Data.Either
+import Data.Functor
 import Data.Maybe (maybe)
 import Data.Text (Text)
 import qualified Data.Text
@@ -9,4 +11,5 @@ import qualified System.IO as SIO
 import Text.Printf (printf)
 
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
+import SomeInternal.Module2
 import qualified SomeInternal.Module2 as Mod2

--- a/data/fourmolu/import-grouping/output-by_scope_then_qualified.hs
+++ b/data/fourmolu/import-grouping/output-by_scope_then_qualified.hs
@@ -1,6 +1,8 @@
 module Main where
 
 import Control.Monad (Monad (..))
+import Data.Either
+import Data.Functor
 import Data.Maybe (maybe)
 import Data.Text (Text)
 import Text.Printf (printf)
@@ -10,5 +12,6 @@ import qualified SomeModule
 import qualified System.IO as SIO
 
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
+import SomeInternal.Module2
 
 import qualified SomeInternal.Module2 as Mod2

--- a/data/fourmolu/import-grouping/output-custom.hs
+++ b/data/fourmolu/import-grouping/output-custom.hs
@@ -1,17 +1,18 @@
 module Main where
 
+import Data.Either
+import Data.Functor
+import SomeInternal.Module2
+
 import Data.Text (Text)
 import qualified Data.Text
 
 import Control.Monad (Monad (..))
-import Data.Either
-import Data.Functor
 import Data.Maybe (maybe)
 import Text.Printf (printf)
 
 import qualified SomeInternal.Module2 as Mod2
 
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
-import SomeInternal.Module2
 import qualified SomeModule
 import qualified System.IO as SIO

--- a/data/fourmolu/import-grouping/output-custom.hs
+++ b/data/fourmolu/import-grouping/output-custom.hs
@@ -4,11 +4,14 @@ import Data.Text (Text)
 import qualified Data.Text
 
 import Control.Monad (Monad (..))
+import Data.Either
+import Data.Functor
 import Data.Maybe (maybe)
 import Text.Printf (printf)
 
 import qualified SomeInternal.Module2 as Mod2
 
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
+import SomeInternal.Module2
 import qualified SomeModule
 import qualified System.IO as SIO

--- a/data/fourmolu/import-grouping/output-preserve.hs
+++ b/data/fourmolu/import-grouping/output-preserve.hs
@@ -1,12 +1,15 @@
 module Main where
 
+import Data.Either
 import Data.Maybe (maybe)
 import Data.Text (Text)
 
 import Control.Monad (Monad (..))
+import Data.Functor
 import qualified Data.Text
 
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
+import SomeInternal.Module2
 import qualified SomeInternal.Module2 as Mod2
 import qualified SomeModule
 import qualified System.IO as SIO

--- a/data/fourmolu/import-grouping/output-single.hs
+++ b/data/fourmolu/import-grouping/output-single.hs
@@ -1,10 +1,13 @@
 module Main where
 
 import Control.Monad (Monad (..))
+import Data.Either
+import Data.Functor
 import Data.Maybe (maybe)
 import Data.Text (Text)
 import qualified Data.Text
 import SomeInternal.Module1 (anotherDefinition, someDefinition)
+import SomeInternal.Module2
 import qualified SomeInternal.Module2 as Mod2
 import qualified SomeModule
 import qualified System.IO as SIO

--- a/src/Ormolu/Config.hs
+++ b/src/Ormolu/Config.hs
@@ -49,6 +49,7 @@ module Ormolu.Config
     matchAllRulePriority,
     matchLocalRulePriority,
     defaultImportRulePriority,
+    ImportListMatcher (..),
     QualifiedImportMatcher (..),
     LetStyle (..),
     InStyle (..),

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -51,13 +51,12 @@ instance Aeson.FromJSON ImportGroupRule where
     igrModuleMatcher <- attemptParseModuleMatcher
 
     igrImportListMatcher <-
-      o .:? "import-list" >>= \case
-        Just "any" -> pure MatchAnyImportDeclaration
-        Just "explicit" -> pure MatchExplicitImportList
-        Just "hiding" -> pure MatchHidingImportClause
-        Just "none" -> pure MatchWholeModuleImport
-        Just other -> Aeson.parseFail $ "Unknown import list matcher: " <> other
-        Nothing -> pure MatchAnyImportDeclaration
+      o .:? "import-list" .!= "any" >>= \case
+        "any" -> pure MatchAnyImportDeclaration
+        "explicit" -> pure MatchExplicitImportList
+        "hiding" -> pure MatchHidingImportClause
+        "none" -> pure MatchWholeModuleImport
+        other -> Aeson.parseFail $ "Unknown import list matcher: " <> other
 
     qualified <- o .:? "qualified"
     igrQualifiedMatcher <- case qualified of

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -49,13 +50,13 @@ instance Aeson.FromJSON ImportGroupRule where
         attemptParseModuleMatcher = parseModuleMatcher <|> failUnknownModuleMatcher
     igrModuleMatcher <- attemptParseModuleMatcher
 
-    importList <- Aeson.parseFieldMaybe @String o "import-list"
-    igrImportListMatcher <- case importList of
-      Just "explicit" -> pure MatchExplicitImportList
-      Just "hiding" -> pure MatchHidingImportClause
-      Just "none" -> pure MatchWholeModuleImport
-      Just other -> Aeson.parseFail $ "Unknown import list matcher: " <> other
-      Nothing -> pure MatchAnyImportDeclaration
+    igrImportListMatcher <-
+      o .:? "import-list" >>= \case
+        Just "explicit" -> pure MatchExplicitImportList
+        Just "hiding" -> pure MatchHidingImportClause
+        Just "none" -> pure MatchWholeModuleImport
+        Just other -> Aeson.parseFail $ "Unknown import list matcher: " <> other
+        Nothing -> pure MatchAnyImportDeclaration
 
     qualified <- o .:? "qualified"
     igrQualifiedMatcher <- case qualified of

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -9,6 +9,7 @@ module Ormolu.Config.Types
     matchAllRulePriority,
     matchLocalRulePriority,
     defaultImportRulePriority,
+    ImportListMatcher (..),
     QualifiedImportMatcher (..),
   )
 where
@@ -35,6 +36,7 @@ instance Aeson.FromJSON ImportGroup where
 
 data ImportGroupRule = ImportGroupRule
   { igrModuleMatcher :: !ImportModuleMatcher,
+    igrImportListMatcher :: !ImportListMatcher,
     igrQualifiedMatcher :: !QualifiedImportMatcher,
     igrPriority :: !ImportRulePriority
   }
@@ -46,6 +48,14 @@ instance Aeson.FromJSON ImportGroupRule where
         failUnknownModuleMatcher = Aeson.parseFail "Unknown or invalid module matcher"
         attemptParseModuleMatcher = parseModuleMatcher <|> failUnknownModuleMatcher
     igrModuleMatcher <- attemptParseModuleMatcher
+
+    importList <- Aeson.parseFieldMaybe @String o "import-list"
+    igrImportListMatcher <- case importList of
+      Just "explicit" -> pure MatchExplicitImportList
+      Just "hiding" -> pure MatchHidingImportClause
+      Just "none" -> pure MatchWholeModuleImport
+      Just other -> Aeson.parseFail $ "Unknown import list matcher: " <> other
+      Nothing -> pure MatchAnyImportDeclaration
 
     qualified <- o .:? "qualified"
     igrQualifiedMatcher <- case qualified of
@@ -74,6 +84,13 @@ matchLocalRulePriority = ImportRulePriority 60 -- Lower priority than "all" but 
 
 defaultImportRulePriority :: ImportRulePriority
 defaultImportRulePriority = ImportRulePriority 50
+
+data ImportListMatcher
+  = MatchExplicitImportList
+  | MatchHidingImportClause
+  | MatchWholeModuleImport
+  | MatchAnyImportDeclaration
+  deriving (Eq, Show)
 
 data QualifiedImportMatcher
   = MatchQualifiedOnly

--- a/src/Ormolu/Config/Types.hs
+++ b/src/Ormolu/Config/Types.hs
@@ -52,6 +52,7 @@ instance Aeson.FromJSON ImportGroupRule where
 
     igrImportListMatcher <-
       o .:? "import-list" >>= \case
+        Just "any" -> pure MatchAnyImportDeclaration
         Just "explicit" -> pure MatchExplicitImportList
         Just "hiding" -> pure MatchHidingImportClause
         Just "none" -> pure MatchWholeModuleImport

--- a/src/Ormolu/Imports.hs
+++ b/src/Ormolu/Imports.hs
@@ -28,7 +28,7 @@ import GHC.Types.PkgQual
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
 import Ormolu.Config (ImportGrouping)
-import Ormolu.Imports.Grouping (Import (..), groupImports, prepareExistingGroups)
+import Ormolu.Imports.Grouping (Import (..), ImportList (..), groupImports, prepareExistingGroups)
 import Ormolu.Utils (notImplemented, showOutputable)
 #if !MIN_VERSION_base(4,20,0)
 import Data.List (foldl')
@@ -51,7 +51,15 @@ normalizeImports respectful localModules importGrouping =
     . prepareExistingGroups importGrouping respectful
   where
     toImport :: (ImportId, x) -> Import
-    toImport (ImportId {..}, _) = Import {importName = importIdName, importQualified}
+    toImport (ImportId {..}, _) =
+      Import
+        { importName = importIdName,
+          importList = case importHiding of
+            Just (ImportListInterpretationOrd Exactly) -> Just ImportList
+            Just (ImportListInterpretationOrd EverythingBut) -> Just HidingList
+            Nothing -> Nothing,
+          importQualified
+        }
 
     g :: LImportDecl GhcPs -> LImportDecl GhcPs
     g (L l ImportDecl {..}) =

--- a/src/Ormolu/Imports/Grouping.hs
+++ b/src/Ormolu/Imports/Grouping.hs
@@ -3,6 +3,7 @@
 
 module Ormolu.Imports.Grouping
   ( Import (..),
+    ImportList (..),
     prepareExistingGroups,
     groupImports,
   )
@@ -28,8 +29,14 @@ newtype ImportGroups = ImportGroups (NonEmpty ImportGroup)
 
 data Import = Import
   { importName :: ModuleName,
+    importList :: Maybe ImportList,
     importQualified :: Bool
   }
+
+data ImportList
+  = ImportList
+  | HidingList
+  deriving (Eq)
 
 importGroupSingleStrategy :: ImportGroups
 importGroupSingleStrategy =
@@ -95,6 +102,7 @@ matchAllImportRule :: ImportGroupRule
 matchAllImportRule =
   ImportGroupRule
     { igrModuleMatcher = MatchAllModules,
+      igrImportListMatcher = Config.MatchAnyImportDeclaration,
       igrQualifiedMatcher = Config.MatchBothQualifiedAndUnqualified,
       igrPriority = Config.matchAllRulePriority
     }
@@ -103,6 +111,7 @@ matchLocalModulesRule :: ImportGroupRule
 matchLocalModulesRule =
   ImportGroupRule
     { igrModuleMatcher = MatchLocalModules,
+      igrImportListMatcher = Config.MatchAnyImportDeclaration,
       igrQualifiedMatcher = Config.MatchBothQualifiedAndUnqualified,
       igrPriority = Config.matchLocalRulePriority
     }
@@ -122,8 +131,13 @@ withUnqualifiedOnly ImportGroupRule {..} =
     }
 
 matchesRule :: Set Cabal.ModuleName -> Import -> ImportGroupRule -> Bool
-matchesRule localMods Import {..} ImportGroupRule {..} = matchesModules && matchesQualified
+matchesRule localMods Import {..} ImportGroupRule {..} = and [matchesImportList, matchesModules, matchesQualified]
   where
+    matchesImportList = case igrImportListMatcher of
+      Config.MatchExplicitImportList -> importList == Just ImportList
+      Config.MatchHidingImportClause -> importList == Just HidingList
+      Config.MatchWholeModuleImport -> importList == Nothing
+      Config.MatchAnyImportDeclaration -> True
     matchesModules = case igrModuleMatcher of
       MatchAllModules -> True
       MatchLocalModules -> ghcModuleNameToCabal importName `Set.member` localMods

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -493,76 +493,55 @@ spanEnd f xs =
 importGroupCustomRules :: NonEmpty ImportGroup
 importGroupCustomRules =
   NonEmpty.fromList
-    [ ImportGroup
-        { igName = Nothing,
-          igRules =
-            NonEmpty.fromList
-              [ ImportGroupRule
-                  { igrModuleMatcher = MatchAllModules,
-                    igrImportListMatcher = MatchWholeModuleImport,
-                    igrQualifiedMatcher = MatchUnqualifiedOnly,
-                    igrPriority = defaultImportRulePriority
-                  }
-              ]
-        },
-      ImportGroup
-        { igName = Nothing,
-          igRules =
-            NonEmpty.fromList
-              [ ImportGroupRule
-                  { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
-                    igrImportListMatcher = MatchAnyImportDeclaration,
-                    igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                    igrPriority = defaultImportRulePriority
-                  }
-              ]
-        },
-      ImportGroup
-        { igName = Nothing,
-          igRules =
-            NonEmpty.fromList
-              [ ImportGroupRule
-                  { igrModuleMatcher = MatchAllModules,
-                    igrImportListMatcher = MatchAnyImportDeclaration,
-                    igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                    igrPriority = ImportRulePriority 100
-                  }
-              ]
-        },
-      ImportGroup
-        { igName = Nothing,
-          igRules =
-            NonEmpty.fromList
-              [ ImportGroupRule
-                  { igrModuleMatcher = MatchGlob (mkGlob "SomeInternal.**"),
-                    igrImportListMatcher = MatchAnyImportDeclaration,
-                    igrQualifiedMatcher = MatchQualifiedOnly,
-                    igrPriority = defaultImportRulePriority
-                  },
-                ImportGroupRule
-                  { igrModuleMatcher = MatchGlob (mkGlob "Unknown.**"),
-                    igrImportListMatcher = MatchAnyImportDeclaration,
-                    igrQualifiedMatcher = MatchUnqualifiedOnly,
-                    igrPriority = defaultImportRulePriority
-                  }
-              ]
-        },
-      ImportGroup
-        { igName = Nothing,
-          igRules =
-            NonEmpty.fromList
-              [ ImportGroupRule
-                  { igrModuleMatcher = MatchLocalModules,
-                    igrImportListMatcher = MatchAnyImportDeclaration,
-                    igrQualifiedMatcher = MatchUnqualifiedOnly,
-                    igrPriority = defaultImportRulePriority
-                  },
-                ImportGroupRule
-                  { igrModuleMatcher = MatchAllModules,
-                    igrImportListMatcher = MatchAnyImportDeclaration,
-                    igrQualifiedMatcher = MatchQualifiedOnly,
-                    igrPriority = defaultImportRulePriority
-                  }
-              ]
-        }
+    [ defaultImportGroup $
+        NonEmpty.fromList
+          [ (defaultImportGroupRule MatchAllModules)
+              { igrImportListMatcher = MatchWholeModuleImport,
+                igrQualifiedMatcher = MatchUnqualifiedOnly
+              }
+          ],
+      defaultImportGroup $
+        NonEmpty.fromList
+          [ defaultImportGroupRule (MatchGlob $ mkGlob "Data.Text")
+          ],
+      defaultImportGroup $
+        NonEmpty.fromList
+          [ (defaultImportGroupRule MatchAllModules)
+              { igrPriority = ImportRulePriority 100
+              }
+          ],
+      defaultImportGroup $
+        NonEmpty.fromList
+          [ (defaultImportGroupRule $ MatchGlob (mkGlob "SomeInternal.**"))
+              { igrQualifiedMatcher = MatchQualifiedOnly
+              },
+            (defaultImportGroupRule $ MatchGlob (mkGlob "Unknown.**"))
+              { igrQualifiedMatcher = MatchUnqualifiedOnly
+              }
+          ],
+      defaultImportGroup $
+        NonEmpty.fromList
+          [ (defaultImportGroupRule MatchLocalModules)
+              { igrQualifiedMatcher = MatchUnqualifiedOnly
+              },
+            (defaultImportGroupRule MatchAllModules)
+              { igrQualifiedMatcher = MatchQualifiedOnly
+              }
+          ]
     ]
+  where
+    defaultImportGroup :: NonEmpty ImportGroupRule -> ImportGroup
+    defaultImportGroup rules =
+      ImportGroup
+        { igName = Nothing,
+          igRules = rules
+        }
+
+    defaultImportGroupRule :: ImportModuleMatcher -> ImportGroupRule
+    defaultImportGroupRule moduleMatcher =
+      ImportGroupRule
+        { igrModuleMatcher = moduleMatcher,
+          igrImportListMatcher = MatchAnyImportDeclaration,
+          igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+          igrPriority = defaultImportRulePriority
+        }

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -13,6 +13,7 @@ import Control.Exception (catch)
 import Control.Monad (forM_, when)
 import Data.Algorithm.DiffContext qualified as Diff
 import Data.Char (isSpace)
+import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (isJust)
 import Data.Set qualified as S
@@ -148,80 +149,7 @@ spec =
               ImportGroupByQualified,
               ImportGroupByScope,
               ImportGroupByScopeThenQualified,
-              ImportGroupCustom . NonEmpty.fromList $
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrImportListMatcher = MatchWholeModuleImport,
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    },
-                  ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    },
-                  ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = ImportRulePriority 100
-                              }
-                          ]
-                    },
-                  ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "SomeInternal.**"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchQualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              },
-                            ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Unknown.**"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    },
-                  ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchLocalModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              },
-                            ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchQualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
+              ImportGroupCustom importGroupCustomRules
             ],
           updateConfig = \igs opts ->
             opts
@@ -561,3 +489,80 @@ spanEnd :: (a -> Bool) -> [a] -> ([a], [a])
 spanEnd f xs =
   let xs' = reverse xs
    in (reverse $ dropWhile f xs', reverse $ takeWhile f xs')
+
+importGroupCustomRules :: NonEmpty ImportGroup
+importGroupCustomRules =
+  NonEmpty.fromList
+    [ ImportGroup
+        { igName = Nothing,
+          igRules =
+            NonEmpty.fromList
+              [ ImportGroupRule
+                  { igrModuleMatcher = MatchAllModules,
+                    igrImportListMatcher = MatchWholeModuleImport,
+                    igrQualifiedMatcher = MatchUnqualifiedOnly,
+                    igrPriority = defaultImportRulePriority
+                  }
+              ]
+        },
+      ImportGroup
+        { igName = Nothing,
+          igRules =
+            NonEmpty.fromList
+              [ ImportGroupRule
+                  { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
+                    igrImportListMatcher = MatchAnyImportDeclaration,
+                    igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                    igrPriority = defaultImportRulePriority
+                  }
+              ]
+        },
+      ImportGroup
+        { igName = Nothing,
+          igRules =
+            NonEmpty.fromList
+              [ ImportGroupRule
+                  { igrModuleMatcher = MatchAllModules,
+                    igrImportListMatcher = MatchAnyImportDeclaration,
+                    igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                    igrPriority = ImportRulePriority 100
+                  }
+              ]
+        },
+      ImportGroup
+        { igName = Nothing,
+          igRules =
+            NonEmpty.fromList
+              [ ImportGroupRule
+                  { igrModuleMatcher = MatchGlob (mkGlob "SomeInternal.**"),
+                    igrImportListMatcher = MatchAnyImportDeclaration,
+                    igrQualifiedMatcher = MatchQualifiedOnly,
+                    igrPriority = defaultImportRulePriority
+                  },
+                ImportGroupRule
+                  { igrModuleMatcher = MatchGlob (mkGlob "Unknown.**"),
+                    igrImportListMatcher = MatchAnyImportDeclaration,
+                    igrQualifiedMatcher = MatchUnqualifiedOnly,
+                    igrPriority = defaultImportRulePriority
+                  }
+              ]
+        },
+      ImportGroup
+        { igName = Nothing,
+          igRules =
+            NonEmpty.fromList
+              [ ImportGroupRule
+                  { igrModuleMatcher = MatchLocalModules,
+                    igrImportListMatcher = MatchAnyImportDeclaration,
+                    igrQualifiedMatcher = MatchUnqualifiedOnly,
+                    igrPriority = defaultImportRulePriority
+                  },
+                ImportGroupRule
+                  { igrModuleMatcher = MatchAllModules,
+                    igrImportListMatcher = MatchAnyImportDeclaration,
+                    igrQualifiedMatcher = MatchQualifiedOnly,
+                    igrPriority = defaultImportRulePriority
+                  }
+              ]
+        }
+    ]

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -493,41 +493,36 @@ spanEnd f xs =
 importGroupCustomRules :: NonEmpty ImportGroup
 importGroupCustomRules =
   NonEmpty.fromList
-    [ defaultImportGroup $
-        NonEmpty.fromList
-          [ (defaultImportGroupRule MatchAllModules)
-              { igrImportListMatcher = MatchWholeModuleImport,
-                igrQualifiedMatcher = MatchUnqualifiedOnly
-              }
-          ],
-      defaultImportGroup $
-        NonEmpty.fromList
-          [ defaultImportGroupRule (MatchGlob $ mkGlob "Data.Text")
-          ],
-      defaultImportGroup $
-        NonEmpty.fromList
-          [ (defaultImportGroupRule MatchAllModules)
-              { igrPriority = ImportRulePriority 100
-              }
-          ],
-      defaultImportGroup $
-        NonEmpty.fromList
-          [ (defaultImportGroupRule $ MatchGlob (mkGlob "SomeInternal.**"))
-              { igrQualifiedMatcher = MatchQualifiedOnly
-              },
-            (defaultImportGroupRule $ MatchGlob (mkGlob "Unknown.**"))
-              { igrQualifiedMatcher = MatchUnqualifiedOnly
-              }
-          ],
-      defaultImportGroup $
-        NonEmpty.fromList
-          [ (defaultImportGroupRule MatchLocalModules)
-              { igrQualifiedMatcher = MatchUnqualifiedOnly
-              },
-            (defaultImportGroupRule MatchAllModules)
-              { igrQualifiedMatcher = MatchQualifiedOnly
-              }
-          ]
+    [ defaultImportGroup . NonEmpty.fromList $
+        [ (defaultImportGroupRule MatchAllModules)
+            { igrImportListMatcher = MatchWholeModuleImport,
+              igrQualifiedMatcher = MatchUnqualifiedOnly
+            }
+        ],
+      defaultImportGroup . NonEmpty.fromList $
+        [ defaultImportGroupRule (MatchGlob $ mkGlob "Data.Text")
+        ],
+      defaultImportGroup . NonEmpty.fromList $
+        [ (defaultImportGroupRule MatchAllModules)
+            { igrPriority = ImportRulePriority 100
+            }
+        ],
+      defaultImportGroup . NonEmpty.fromList $
+        [ (defaultImportGroupRule $ MatchGlob (mkGlob "SomeInternal.**"))
+            { igrQualifiedMatcher = MatchQualifiedOnly
+            },
+          (defaultImportGroupRule $ MatchGlob (mkGlob "Unknown.**"))
+            { igrQualifiedMatcher = MatchUnqualifiedOnly
+            }
+        ],
+      defaultImportGroup . NonEmpty.fromList $
+        [ (defaultImportGroupRule MatchLocalModules)
+            { igrQualifiedMatcher = MatchUnqualifiedOnly
+            },
+          (defaultImportGroupRule MatchAllModules)
+            { igrQualifiedMatcher = MatchQualifiedOnly
+            }
+        ]
     ]
   where
     defaultImportGroup :: NonEmpty ImportGroupRule -> ImportGroup

--- a/tests/Ormolu/Config/PrinterOptsSpec.hs
+++ b/tests/Ormolu/Config/PrinterOptsSpec.hs
@@ -154,7 +154,20 @@ spec =
                       igRules =
                         NonEmpty.fromList
                           [ ImportGroupRule
+                              { igrModuleMatcher = MatchAllModules,
+                                igrImportListMatcher = MatchWholeModuleImport,
+                                igrQualifiedMatcher = MatchUnqualifiedOnly,
+                                igrPriority = defaultImportRulePriority
+                              }
+                          ]
+                    },
+                  ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -166,6 +179,7 @@ spec =
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchAllModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = ImportRulePriority 100
                               }
@@ -177,11 +191,13 @@ spec =
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "SomeInternal.**"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchQualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               },
                             ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "Unknown.**"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchUnqualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -193,11 +209,13 @@ spec =
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchLocalModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchUnqualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               },
                             ImportGroupRule
                               { igrModuleMatcher = MatchAllModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchQualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               }

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -8,7 +8,7 @@ import Data.List (isInfixOf)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Yaml qualified as Yaml
-import Ormolu.Config (FourmoluConfig (..), ImportGroup (..), ImportGroupRule (..), ImportGrouping (..), ImportModuleMatcher (..), ImportRulePriority (ImportRulePriority), PrinterOpts (..), QualifiedImportMatcher (MatchBothQualifiedAndUnqualified, MatchQualifiedOnly, MatchUnqualifiedOnly), defaultImportRulePriority, matchAllRulePriority, resolvePrinterOpts)
+import Ormolu.Config (FourmoluConfig (..), ImportGroup (..), ImportGroupRule (..), ImportGrouping (..), ImportListMatcher (..), ImportModuleMatcher (..), ImportRulePriority (ImportRulePriority), PrinterOpts (..), QualifiedImportMatcher (MatchBothQualifiedAndUnqualified, MatchQualifiedOnly, MatchUnqualifiedOnly), defaultImportRulePriority, matchAllRulePriority, resolvePrinterOpts)
 import Ormolu.Fixity (ModuleReexports (..))
 import Ormolu.Utils.Glob (mkGlob)
 import Test.Hspec
@@ -82,8 +82,108 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchAllModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = matchAllRulePriority
+                              }
+                          ]
+                    }
+                ]
+        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
+      it "enables the 'explicit' import list option" $ do
+        config <-
+          Yaml.decodeThrow . Char8.pack . unlines $
+            [ "import-grouping:",
+              "  - rules:",
+              "      - glob: \"**\"",
+              "        import-list: explicit"
+            ]
+        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
+            expectedRules =
+              NonEmpty.fromList
+                [ ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
+                                igrImportListMatcher = MatchExplicitImportList,
+                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                                igrPriority = defaultImportRulePriority
+                              }
+                          ]
+                    }
+                ]
+        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
+      it "enables the 'hiding' import list option" $ do
+        config <-
+          Yaml.decodeThrow . Char8.pack . unlines $
+            [ "import-grouping:",
+              "  - rules:",
+              "      - glob: \"**\"",
+              "        import-list: hiding"
+            ]
+        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
+            expectedRules =
+              NonEmpty.fromList
+                [ ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
+                                igrImportListMatcher = MatchHidingImportClause,
+                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                                igrPriority = defaultImportRulePriority
+                              }
+                          ]
+                    }
+                ]
+        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
+      it "enables the 'none' import list option" $ do
+        config <-
+          Yaml.decodeThrow . Char8.pack . unlines $
+            [ "import-grouping:",
+              "  - rules:",
+              "      - glob: \"**\"",
+              "        import-list: none"
+            ]
+        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
+            expectedRules =
+              NonEmpty.fromList
+                [ ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
+                                igrImportListMatcher = MatchWholeModuleImport,
+                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                                igrPriority = defaultImportRulePriority
+                              }
+                          ]
+                    }
+                ]
+        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
+      it "disregards the presence or absence of import list and hiding clause by default" $ do
+        config <-
+          Yaml.decodeThrow . Char8.pack . unlines $
+            [ "import-grouping:",
+              "  - rules:",
+              "      - glob: \"**\""
+            ]
+        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
+            expectedRules =
+              NonEmpty.fromList
+                [ ImportGroup
+                    { igName = Nothing,
+                      igRules =
+                        NonEmpty.fromList
+                          [ ImportGroupRule
+                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
+                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                                igrPriority = defaultImportRulePriority
                               }
                           ]
                     }
@@ -106,6 +206,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "**"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchQualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -130,6 +231,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "**"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchUnqualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -154,6 +256,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchAllModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = ImportRulePriority 55
                               }
@@ -177,6 +280,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "Data.Text.**"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -200,6 +304,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchLocalModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -223,6 +328,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchAllModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = matchAllRulePriority
                               }
@@ -266,6 +372,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -277,6 +384,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchAllModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = ImportRulePriority 100
                               }
@@ -288,11 +396,13 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchLocalModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchUnqualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               },
                             ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "Control.Monad"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchUnqualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -304,11 +414,13 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchLocalModules,
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchQualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               },
                             ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "Control.Monad"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchQualifiedOnly,
                                 igrPriority = defaultImportRulePriority
                               }
@@ -320,6 +432,7 @@ spec = do
                         NonEmpty.fromList
                           [ ImportGroupRule
                               { igrModuleMatcher = MatchGlob (mkGlob "Control.Monad.**"),
+                                igrImportListMatcher = MatchAnyImportDeclaration,
                                 igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
                                 igrPriority = defaultImportRulePriority
                               }

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -80,15 +80,7 @@ spec = do
               NonEmpty.fromList
                 [ ImportGroup
                     { igName = Just "Some name",
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = matchAllRulePriority
-                              }
-                          ]
+                      igRules = NonEmpty.fromList [(defaultImportGroupRule MatchAllModules) {igrPriority = matchAllRulePriority}]
                     }
                 ]
         actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
@@ -177,75 +169,31 @@ spec = do
               NonEmpty.fromList
                 [ ImportGroup
                     { igName = Just "Text modules",
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Data.Text"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
+                      igRules = NonEmpty.fromList [defaultImportGroupRule (MatchGlob $ mkGlob "Data.Text")]
                     },
                   ImportGroup
                     { igName = Just "The rest",
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = ImportRulePriority 100
-                              }
-                          ]
+                      igRules = NonEmpty.fromList [(defaultImportGroupRule MatchAllModules) {igrPriority = ImportRulePriority 100}]
                     },
                   ImportGroup
                     { igName = Just "My internals and monads unqualified",
                       igRules =
                         NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchLocalModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              },
-                            ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Control.Monad"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
+                          [ (defaultImportGroupRule MatchLocalModules) {igrQualifiedMatcher = MatchUnqualifiedOnly},
+                            (defaultImportGroupRule (MatchGlob $ mkGlob "Control.Monad")) {igrQualifiedMatcher = MatchUnqualifiedOnly}
                           ]
                     },
                   ImportGroup
                     { igName = Just "My internals and monads qualified",
                       igRules =
                         NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchLocalModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchQualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              },
-                            ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Control.Monad"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchQualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
+                          [ (defaultImportGroupRule MatchLocalModules) {igrQualifiedMatcher = MatchQualifiedOnly},
+                            (defaultImportGroupRule (MatchGlob $ mkGlob "Control.Monad")) {igrQualifiedMatcher = MatchQualifiedOnly}
                           ]
                     },
                   ImportGroup
                     { igName = Just "Specific monads",
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Control.Monad.**"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
+                      igRules = NonEmpty.fromList [defaultImportGroupRule (MatchGlob $ mkGlob "Control.Monad.**")]
                     }
                 ]
         actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -37,38 +37,6 @@ spec = do
       poIndentation (resolvePrinterOpts configs) `shouldBe` 4
 
     context "when using an import grouping configuration" $ do
-      let checkRuleAttribute desc ruleConfig applyExpectedChange =
-            it ("enables the " ++ desc ++ " rule option") $ do
-              let baseArbitraryYamlConfig =
-                    [ "import-grouping:",
-                      "  - rules:",
-                      "      - glob: \"**\""
-                    ]
-                  yamlConfigChange = map ("        " ++) ruleConfig
-                  yamlConfig = unlines (baseArbitraryYamlConfig ++ yamlConfigChange)
-
-                  downCustomRules (ImportGroupCustom customRules) = Just customRules
-                  downCustomRules _ = Nothing
-                  downSingleton (a :| []) = Just a
-                  downSingleton _ = Nothing
-                  accessTestedRule = downCustomRules >=> downSingleton >=> downSingleton . igRules
-
-                  baseArbitraryConfig =
-                    ImportGroupRule
-                      { igrModuleMatcher = MatchGlob (mkGlob "**"),
-                        igrImportListMatcher = MatchAnyImportDeclaration,
-                        igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                        igrPriority = defaultImportRulePriority
-                      }
-                  expectedRuleConfig = applyExpectedChange baseArbitraryConfig
-
-              config <- Yaml.decodeThrow (Char8.pack yamlConfig)
-
-              let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-              case actualStrategy >>= accessTestedRule of
-                Nothing -> expectationFailure "A single tested rule change was expected"
-                Just actualRule -> actualRule `shouldBe` expectedRuleConfig
-
       it "parses 'legacy' as the 'ImportGroupLegacy' import grouping strategy" $ do
         config <- Yaml.decodeThrow "import-grouping: legacy"
         let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
@@ -125,6 +93,46 @@ spec = do
                 ]
         actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
 
+      let checkRule desc yamlRuleConfig expectedRuleConfig =
+            it ("parses " ++ desc) $ do
+              let baseArbitraryYamlConfig =
+                    [ "import-grouping:",
+                      "  - rules:",
+                      "      -"
+                    ]
+                  yamlConfigChange = map ("        " ++) yamlRuleConfig
+                  yamlConfig = unlines (baseArbitraryYamlConfig ++ yamlConfigChange)
+
+                  downCustomRules (ImportGroupCustom customRules) = Just customRules
+                  downCustomRules _ = Nothing
+                  downSingleton (a :| []) = Just a
+                  downSingleton _ = Nothing
+                  accessTestedRule = downCustomRules >=> downSingleton >=> downSingleton . igRules
+
+              config <- Yaml.decodeThrow (Char8.pack yamlConfig)
+
+              let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
+              case actualStrategy >>= accessTestedRule of
+                Nothing -> expectationFailure "A single tested rule change was expected"
+                Just actualRule -> actualRule `shouldBe` expectedRuleConfig
+          checkRuleAttribute desc yamlRuleConfig applyExpectedChange = do
+            let baseArbitraryYamlConfig = ["glob: \"**\""]
+                yamlConfig = baseArbitraryYamlConfig ++ yamlRuleConfig
+
+                baseArbitraryConfig = defaultImportGroupRule (MatchGlob $ mkGlob "**")
+                expectedRuleConfig = applyExpectedChange baseArbitraryConfig
+            checkRule
+              ("rules with the " ++ desc ++ " rule option")
+              yamlConfig
+              expectedRuleConfig
+
+      checkRule "the 'glob' rule" ["glob: Data.Text.**"] (defaultImportGroupRule . MatchGlob $ mkGlob "Data.Text.**")
+      checkRule
+        "the 'match' rule for all modules (with a 100 priority)"
+        ["match: all"]
+        ((defaultImportGroupRule MatchAllModules) {igrPriority = ImportRulePriority 100})
+      checkRule "the 'match' rule for local modules" ["match: local-modules"] (defaultImportGroupRule MatchLocalModules)
+
       checkRuleAttribute "'any' import list" ["import-list: any"] $ \config -> config {igrImportListMatcher = MatchAnyImportDeclaration}
       checkRuleAttribute "'explicit' import list" ["import-list: explicit"] $ \config -> config {igrImportListMatcher = MatchExplicitImportList}
       checkRuleAttribute "'hiding' import list" ["import-list: hiding"] $ \config -> config {igrImportListMatcher = MatchHidingImportClause}
@@ -137,78 +145,6 @@ spec = do
       checkRuleAttribute "'priority' (55 priority example)" ["priority: 55"] $ \config -> config {igrPriority = ImportRulePriority 55}
       checkRuleAttribute "'priority' (80 priority example)" ["priority: 80"] $ \config -> config {igrPriority = ImportRulePriority 80}
 
-      it "parses a 'glob' rule" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - glob: Data.Text.**"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "Data.Text.**"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "parses a 'match' rule for local modules" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - match: local-modules"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchLocalModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "parses a 'match' rule for all modules" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - match: all"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = matchAllRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
       it "parses multiple group configurations and rules in their order of appearance in the configuration" $ do
         config <-
           Yaml.decodeThrow . Char8.pack . unlines $
@@ -324,3 +260,12 @@ spec = do
               Left (Yaml.AesonException msg) -> "Unknown or invalid module matcher" `isInfixOf` msg
               _ -> False
         decodeResult `shouldSatisfy` isAnUnknownModuleMatcher
+
+defaultImportGroupRule :: ImportModuleMatcher -> ImportGroupRule
+defaultImportGroupRule moduleMatcher =
+  ImportGroupRule
+    { igrModuleMatcher = moduleMatcher,
+      igrImportListMatcher = MatchAnyImportDeclaration,
+      igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+      igrPriority = defaultImportRulePriority
+    }

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -3,8 +3,10 @@
 -- | Tests for Fourmolu file configuration.
 module Ormolu.ConfigSpec (spec) where
 
+import Control.Monad ((>=>))
 import Data.ByteString.Char8 qualified as Char8
 import Data.List (isInfixOf)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Yaml qualified as Yaml
@@ -35,6 +37,38 @@ spec = do
       poIndentation (resolvePrinterOpts configs) `shouldBe` 4
 
     context "when using an import grouping configuration" $ do
+      let checkRuleAttribute desc ruleConfig applyExpectedChange =
+            it ("enables the " ++ desc ++ " rule attribute") $ do
+              let baseArbitraryYamlConfig =
+                    [ "import-grouping:",
+                      "  - rules:",
+                      "      - glob: \"**\""
+                    ]
+                  yamlConfigChange = map ("        " ++) ruleConfig
+                  yamlConfig = unlines (baseArbitraryYamlConfig ++ yamlConfigChange)
+
+                  downCustomRules (ImportGroupCustom customRules) = Just customRules
+                  downCustomRules _ = Nothing
+                  downSingleton (a :| []) = Just a
+                  downSingleton _ = Nothing
+                  accessTestedRule = downCustomRules >=> downSingleton >=> downSingleton . igRules
+
+                  baseArbitraryConfig =
+                    ImportGroupRule
+                      { igrModuleMatcher = MatchGlob (mkGlob "**"),
+                        igrImportListMatcher = MatchAnyImportDeclaration,
+                        igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
+                        igrPriority = defaultImportRulePriority
+                      }
+                  expectedRuleConfig = applyExpectedChange baseArbitraryConfig
+
+              config <- Yaml.decodeThrow (Char8.pack yamlConfig)
+
+              let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
+              case actualStrategy >>= accessTestedRule of
+                Nothing -> expectationFailure "A single tested rule change was expected"
+                Just actualRule -> actualRule `shouldBe` expectedRuleConfig
+
       it "parses 'legacy' as the 'ImportGroupLegacy' import grouping strategy" $ do
         config <- Yaml.decodeThrow "import-grouping: legacy"
         let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
@@ -90,105 +124,12 @@ spec = do
                     }
                 ]
         actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "enables the 'explicit' import list option" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - glob: \"**\"",
-              "        import-list: explicit"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
-                                igrImportListMatcher = MatchExplicitImportList,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "enables the 'hiding' import list option" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - glob: \"**\"",
-              "        import-list: hiding"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
-                                igrImportListMatcher = MatchHidingImportClause,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "enables the 'none' import list option" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - glob: \"**\"",
-              "        import-list: none"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
-                                igrImportListMatcher = MatchWholeModuleImport,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "disregards the presence or absence of import list and hiding clause by default" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - glob: \"**\""
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
+
+      checkRuleAttribute "'explicit' import list" ["import-list: explicit"] $ \config -> config {igrImportListMatcher = MatchExplicitImportList}
+      checkRuleAttribute "'hiding' import list" ["import-list: hiding"] $ \config -> config {igrImportListMatcher = MatchHidingImportClause}
+      checkRuleAttribute "'none' import list" ["import-list: none"] $ \config -> config {igrImportListMatcher = MatchWholeModuleImport}
+      checkRuleAttribute "default import list" [] $ \config -> config {igrImportListMatcher = MatchAnyImportDeclaration}
+
       it "enables the 'qualified' rule option" $ do
         config <-
           Yaml.decodeThrow . Char8.pack . unlines $

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -125,6 +125,7 @@ spec = do
                 ]
         actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
 
+      checkRuleAttribute "'any' import list" ["import-list: any"] $ \config -> config {igrImportListMatcher = MatchAnyImportDeclaration}
       checkRuleAttribute "'explicit' import list" ["import-list: explicit"] $ \config -> config {igrImportListMatcher = MatchExplicitImportList}
       checkRuleAttribute "'hiding' import list" ["import-list: hiding"] $ \config -> config {igrImportListMatcher = MatchHidingImportClause}
       checkRuleAttribute "'none' import list" ["import-list: none"] $ \config -> config {igrImportListMatcher = MatchWholeModuleImport}

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -8,7 +8,7 @@ import Data.List (isInfixOf)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Yaml qualified as Yaml
-import Ormolu.Config (FourmoluConfig (..), ImportGroup (..), ImportGroupRule (..), ImportGrouping (..), ImportListMatcher (..), ImportModuleMatcher (..), ImportRulePriority (ImportRulePriority), PrinterOpts (..), QualifiedImportMatcher (MatchBothQualifiedAndUnqualified, MatchQualifiedOnly, MatchUnqualifiedOnly), defaultImportRulePriority, matchAllRulePriority, resolvePrinterOpts)
+import Ormolu.Config
 import Ormolu.Fixity (ModuleReexports (..))
 import Ormolu.Utils.Glob (mkGlob)
 import Test.Hspec

--- a/tests/Ormolu/ConfigSpec.hs
+++ b/tests/Ormolu/ConfigSpec.hs
@@ -38,7 +38,7 @@ spec = do
 
     context "when using an import grouping configuration" $ do
       let checkRuleAttribute desc ruleConfig applyExpectedChange =
-            it ("enables the " ++ desc ++ " rule attribute") $ do
+            it ("enables the " ++ desc ++ " rule option") $ do
               let baseArbitraryYamlConfig =
                     [ "import-grouping:",
                       "  - rules:",
@@ -131,81 +131,12 @@ spec = do
       checkRuleAttribute "'none' import list" ["import-list: none"] $ \config -> config {igrImportListMatcher = MatchWholeModuleImport}
       checkRuleAttribute "default import list" [] $ \config -> config {igrImportListMatcher = MatchAnyImportDeclaration}
 
-      it "enables the 'qualified' rule option" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - glob: \"**\"",
-              "        qualified: yes"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchQualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "disables the 'qualified' rule option" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - glob: \"**\"",
-              "        qualified: no"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchGlob (mkGlob "**"),
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchUnqualifiedOnly,
-                                igrPriority = defaultImportRulePriority
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
-      it "decodes the 'priority' rule option" $ do
-        config <-
-          Yaml.decodeThrow . Char8.pack . unlines $
-            [ "import-grouping:",
-              "  - rules:",
-              "      - match: all",
-              "        priority: 55"
-            ]
-        let actualStrategy = poImportGrouping (cfgFilePrinterOpts config)
-            expectedRules =
-              NonEmpty.fromList
-                [ ImportGroup
-                    { igName = Nothing,
-                      igRules =
-                        NonEmpty.fromList
-                          [ ImportGroupRule
-                              { igrModuleMatcher = MatchAllModules,
-                                igrImportListMatcher = MatchAnyImportDeclaration,
-                                igrQualifiedMatcher = MatchBothQualifiedAndUnqualified,
-                                igrPriority = ImportRulePriority 55
-                              }
-                          ]
-                    }
-                ]
-        actualStrategy `shouldBe` Just (ImportGroupCustom expectedRules)
+      checkRuleAttribute "'qualified: yes'" ["qualified: yes"] $ \config -> config {igrQualifiedMatcher = MatchQualifiedOnly}
+      checkRuleAttribute "'qualified: no'" ["qualified: no"] $ \config -> config {igrQualifiedMatcher = MatchUnqualifiedOnly}
+
+      checkRuleAttribute "'priority' (55 priority example)" ["priority: 55"] $ \config -> config {igrPriority = ImportRulePriority 55}
+      checkRuleAttribute "'priority' (80 priority example)" ["priority: 80"] $ \config -> config {igrPriority = ImportRulePriority 80}
+
       it "parses a 'glob' rule" $ do
         config <-
           Yaml.decodeThrow . Char8.pack . unlines $

--- a/web/site/pages/config/import-grouping.md
+++ b/web/site/pages/config/import-grouping.md
@@ -31,6 +31,7 @@ The following rule types are defined:
 
 In addition to the type, certain attributes can be added to rules:
 
+- `import-list: explicit | hiding | none`: when set, `explicit` only matches import declarations with an explicit import list, `hiding` only matches import declarations with the `hiding` clause, `none` only matches import declarations on a whole module (no explicit import list or `hiding` clause). When absent, import declarations will match regardless of import lists or `hiding` clauses.
 - `qualified: <yes | no>`: when set, `yes` only matches import declarations that are qualified, unlike `no` which only matches import declarations that are not qualified.
 - `priority: <int>`: in cases multiple rules from different groups match an import declaration, the value associated to `priority` is used as a tie-breaker: the matching rule with the lowest priority wins, and the import declaration will belong to the group with that rule.
 

--- a/web/site/pages/config/import-grouping.md
+++ b/web/site/pages/config/import-grouping.md
@@ -31,7 +31,7 @@ The following rule types are defined:
 
 In addition to the type, certain attributes can be added to rules:
 
-- `import-list: explicit | hiding | none`: when set, `explicit` only matches import declarations with an explicit import list, `hiding` only matches import declarations with the `hiding` clause, `none` only matches import declarations on a whole module (no explicit import list or `hiding` clause). When absent, import declarations will match regardless of import lists or `hiding` clauses.
+- `import-list: any | explicit | hiding | none`: when set, `explicit` only matches import declarations with an explicit import list, `hiding` only matches import declarations with the `hiding` clause, `none` only matches import declarations on a whole module (no explicit import list or `hiding` clause), `any` matches all import declarations regardless of import lists or `hiding` clauses. When absent, `any` is assumed.
 - `qualified: <yes | no>`: when set, `yes` only matches import declarations that are qualified, unlike `no` which only matches import declarations that are not qualified.
 - `priority: <int>`: in cases multiple rules from different groups match an import declaration, the value associated to `priority` is used as a tie-breaker: the matching rule with the lowest priority wins, and the import declaration will belong to the group with that rule.
 


### PR DESCRIPTION
This PR is an attempt to resolve #519: it adds a new `import-list` option to import grouping rules.

The current proposal adds the `import-list` rule option, with the following values:

- `explicit`: matches import declarations with an explicit import list
- `hiding`: matches import declarations with an explicit `hiding` clause
- `none`: matches import declarations without an explicit import list of `hiding` clause (original request from #519)
- no value: matches any import declaration, regardless of presence or absence of an import list or `hiding` clause.

Example configuration:

```yaml
import-grouping:
  - name: "Text modules"
    rules:
      - glob: Data.Text
      - import-list: none
```

While #519 focuses on identifying whole module imports only, this PR also attempts to see what identifying the other cases would look like as well: explicit import lists and `hiding` clauses. Though I'm not sure there are scenarios where the latter would be very useful. So ignoring those might be preferable to keep the code simple... What do you think?

Note that this PR does not change how we interpret `match: all` or local modules as briefly discussed in #519, as it seems out of scope here.

Closes #519