### PR TITLE
Break out / generalize ParsedFunRepr

### DIFF
--- a/fourmolu.cabal
+++ b/fourmolu.cabal
@@ -84,6 +84,7 @@ library
     Ormolu.Printer.Meat.Module
     Ormolu.Printer.Meat.Pragma
     Ormolu.Printer.Meat.Type
+    Ormolu.Printer.Meat.Type.Function
     Ormolu.Printer.Operators
     Ormolu.Printer.SpanStream
     Ormolu.Processing.Common

--- a/src/Ormolu/Printer/Meat/Declaration/Data.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Data.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Renedring of data type declarations.
 module Ormolu.Printer.Meat.Declaration.Data
@@ -154,7 +156,7 @@ data DerivingClauseSortKey
   deriving (Eq, Ord)
 
 p_conDecl :: Choice "singleRecCon" -> ConDecl GhcPs -> R ()
-p_conDecl _ ConDeclGADT {..} = do
+p_conDecl _ decl@ConDeclGADT {..} = do
   mapM_ (p_hsDoc Pipe (With #endNewline)) con_doc
   switchLayout conDeclSpn $ do
     let c :| cs = con_names
@@ -162,28 +164,7 @@ p_conDecl _ ConDeclGADT {..} = do
     unless (null cs) . inci $ do
       commaDel
       sep commaDel p_rdrName cs
-    inci $ do
-      let conTy = case con_g_args of
-            PrefixConGADT NoExtField xs ->
-              let go (HsScaled a b) t = addCLocA t b (HsFunTy NoExtField a b t)
-               in foldr go con_res_ty xs
-            RecConGADT _ r ->
-              addCLocA r con_res_ty $
-                HsFunTy
-                  NoExtField
-                  (HsUnrestrictedArrow noAnn)
-                  (la2la $ HsRecTy noAnn <$> r)
-                  con_res_ty
-          qualTy = case con_mb_cxt of
-            Nothing -> conTy
-            Just qs ->
-              addCLocA qs conTy $
-                HsQualTy NoExtField qs conTy
-          quantifiedTy :: LHsType GhcPs
-          quantifiedTy =
-            addCLocA con_bndrs qualTy $
-              hsOuterTyVarBndrsToHsType (unLoc con_bndrs) qualTy
-      p_hsTypeAnnotation quantifiedTy
+    inci $ p_hsFun decl
   where
     conDeclSpn =
       fmap getLocA (NE.toList con_names)
@@ -336,6 +317,98 @@ p_hsDerivingClause HsDerivingClause {..} = do
           txt "via"
           space
           located sigTy p_hsSigType
+
+----------------------------------------------------------------------------
+-- FunRepr ConDeclGADT
+
+-- | ConDecl, except should only be called with the ConDeclGADT constructor.
+type ConDeclGADT = ConDecl
+
+-- | FunRepr ConDeclGADT renders a GADT constructor type annotation, which looks
+-- similar to a function type, except the arguments of the function have two
+-- additional capabilities:
+--   * They can specify UNPACK/strictness
+--   * It can be a single argument with a record fields syntax
+instance FunRepr (ConDeclGADT GhcPs) where
+  parseFunRepr = \case
+    L _ ConDeclGADT {..} ->
+      fst
+        . addSig
+        . addOuter con_bndrs
+        . addCtx con_mb_cxt
+        . addArgs con_g_args
+        $ mkRet con_res_ty
+    _ -> error "parseFunRepr @ConDeclGADT unexpectedly called on non-GADT constructor"
+    where
+      addSig (next, loc) = (ParsedFunSig {sig = (), next}, loc)
+      addOuter (L ann bndrs) =
+        case bndrs :: HsOuterSigTyVarBndrs GhcPs of
+          HsOuterImplicit {} -> id
+          HsOuterExplicit _ bndrs' -> \(next, loc) ->
+            let loc' = combineSrcSpans loc (getHasLoc ann)
+                fun =
+                  ParsedFunForall
+                    { tele = L (l2l loc') $ mkHsForAllInvisTele noAnn bndrs',
+                      next
+                    }
+             in (fun, loc')
+      addCtx = \case
+        Nothing -> id
+        Just ctxs -> \(next, loc) ->
+          let loc' = combineSrcSpans loc (getHasLoc ctxs)
+              fun = ParsedFunQuals {ctxs = [L (l2l loc') ctxs], next}
+           in (fun, loc')
+      addArgs details =
+        case details :: HsConDeclGADTDetails GhcPs of
+          PrefixConGADT _ fields ->
+            let go (HsScaled arrow field) (next, loc) =
+                  let loc' = combineSrcSpans loc (getHasLoc field)
+                      (arg, doc) =
+                        case field of
+                          L _ (HsDocTy _ arg_ doc_) -> (arg_, Just doc_)
+                          _ -> (field, Nothing)
+                      fun =
+                        ParsedFunArg
+                          { span = l2l loc',
+                            arg = Left <$> arg,
+                            doc,
+                            arrow,
+                            next
+                          }
+                   in (fun, loc')
+             in foldr (\field acc -> go field . acc) id fields
+          RecConGADT _ fields -> \(next, loc) ->
+            let loc' = combineSrcSpans (getHasLoc fields) loc
+                fun =
+                  ParsedFunArg
+                    { span = l2l loc',
+                      arg = la2la $ Right <$> fields,
+                      doc = Nothing,
+                      arrow = HsUnrestrictedArrow noAnn,
+                      next
+                    }
+             in (fun, loc')
+      mkRet ty =
+        let fun =
+              case ty of
+                L _ (HsDocTy _ ret doc) -> ParsedFunReturn {ret, doc = Just doc}
+                ret -> ParsedFunReturn {ret, doc = Nothing}
+         in (fun, getHasLoc ty)
+
+  type FunReprCtx (ConDeclGADT GhcPs) = HsType GhcPs
+  renderFunReprCtx = p_hsType
+
+  -- Invariant: Exactly one of the following must be true:
+  --   * There's exactly one 'Right' arg
+  --   * There are zero or more 'Left' args
+  type FunReprArg (ConDeclGADT GhcPs) = Either (HsType GhcPs) [LocatedA (ConDeclField GhcPs)]
+  renderFunReprArg = either p_hsType p_conDeclFields
+
+  type FunReprArr (ConDeclGADT GhcPs) = HsType GhcPs
+  renderFunReprArr = p_hsType
+
+  type FunReprRet (ConDeclGADT GhcPs) = HsType GhcPs
+  renderFunReprRet = p_hsType
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1438,17 +1438,22 @@ instance FunRepr (HsExpr GhcPs) where
   parseFunRepr = \case
     -- `forall a. _`
     L ann (HsForAll _ tele expr) ->
-      ParsedFunForall (L ann tele) (parseFunRepr expr)
+      ParsedFunForall {tele = L ann tele, next = parseFunRepr expr}
     -- `HasCallStack => _`
     expr@(L _ HsQual {}) ->
       let (ctxs, rest) = getContexts expr
-       in ParsedFunQuals ctxs (parseFunRepr rest)
+       in ParsedFunQuals {ctxs, next = parseFunRepr rest}
     -- `Int -> _`
-    expr@(L _ HsFunArr {}) ->
-      let (args, ret) = getArgsAndReturn expr
-       in ParsedFunArgs args (parseFunRepr ret)
+    L ann (HsFunArr _ arrow item r) ->
+      ParsedFunArg
+        { span = ann,
+          item,
+          doc = Nothing,
+          arrow,
+          next = parseFunRepr r
+        }
     -- `_ -> Int`
-    expr -> ParsedFunReturn (expr, Nothing)
+    expr -> ParsedFunReturn {item = expr, doc = Nothing}
     where
       getContexts =
         let go ctxs = \case
@@ -1456,13 +1461,6 @@ instance FunRepr (HsExpr GhcPs) where
                 go (L ann ctx : ctxs) expr
               expr ->
                 (reverse ctxs, expr)
-         in go []
-      getArgsAndReturn =
-        let go args = \case
-              L ann (HsFunArr _ arrow l r) ->
-                go (L ann (l, Nothing, arrow) : args) r
-              expr ->
-                (reverse args, expr)
          in go []
 
 ----------------------------------------------------------------------------

--- a/src/Ormolu/Printer/Meat/Declaration/Value.hs
+++ b/src/Ormolu/Printer/Meat/Declaration/Value.hs
@@ -1434,26 +1434,31 @@ p_hsQuote = \case
 
 -- | Function types in expressions, e.g. with -XRequiredTypeArguments
 instance FunRepr (HsExpr GhcPs) where
-  renderFunItem = p_hsExpr
   parseFunRepr = \case
     -- `forall a. _`
     L ann (HsForAll _ tele expr) ->
-      ParsedFunForall {tele = L ann tele, next = parseFunRepr expr}
+      ParsedFunForall
+        { tele = L ann tele,
+          next = parseFunRepr expr
+        }
     -- `HasCallStack => _`
     expr@(L _ HsQual {}) ->
       let (ctxs, rest) = getContexts expr
-       in ParsedFunQuals {ctxs, next = parseFunRepr rest}
+       in ParsedFunQuals
+            { ctxs,
+              next = parseFunRepr rest
+            }
     -- `Int -> _`
-    L ann (HsFunArr _ arrow item r) ->
+    L ann (HsFunArr _ arrow arg r) ->
       ParsedFunArg
         { span = ann,
-          item,
+          arg,
           doc = Nothing,
           arrow,
           next = parseFunRepr r
         }
     -- `_ -> Int`
-    expr -> ParsedFunReturn {item = expr, doc = Nothing}
+    ret -> ParsedFunReturn {ret, doc = Nothing}
     where
       getContexts =
         let go ctxs = \case
@@ -1462,6 +1467,11 @@ instance FunRepr (HsExpr GhcPs) where
               expr ->
                 (reverse ctxs, expr)
          in go []
+
+  renderFunReprArg = p_hsExpr
+  renderFunReprCtx = p_hsExpr
+  renderFunReprArr = p_hsExpr
+  renderFunReprRet = p_hsExpr
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Rendering of types.
 module Ormolu.Printer.Meat.Type
@@ -29,27 +30,19 @@ module Ormolu.Printer.Meat.Type
 where
 
 import Control.Monad
-import Control.Monad.Cont qualified as Cont
-import Control.Monad.State qualified as State
-import Control.Monad.Trans qualified as Trans
-import Data.Choice (Choice, pattern Is, pattern Isn't, pattern With, pattern Without)
-import Data.Choice qualified as Choice
-import Data.Foldable (traverse_)
-import Data.Functor ((<&>))
-import Data.List (sortOn)
-import Data.Maybe (isJust)
+import Data.Choice (pattern Is, pattern With, pattern Without)
 import GHC.Data.Strict qualified as Strict
 import GHC.Hs hiding (isPromoted)
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc
 import GHC.Types.Var
-import GHC.Utils.Outputable (Outputable)
 import Ormolu.Config
 import Ormolu.Printer.Combinators
 import Ormolu.Printer.Meat.Common
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.OpTree (p_tyOpTree, tyOpTree)
 import Ormolu.Printer.Meat.Declaration.StringLiteral
 import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsUntypedSplice)
+import Ormolu.Printer.Meat.Type.Function
 import Ormolu.Printer.Operators
 import Ormolu.Utils
 
@@ -137,19 +130,8 @@ p_hsType = \case
     --       String
     --       -- | Age
     --       Int
-    usePipe <-
-      getPrinterOpt poFunctionArrows <&> \case
-        TrailingArrows -> True
-        LeadingArrows -> False
-        LeadingArgsArrows -> False
-    if usePipe
-      then do
-        p_hsDoc Pipe (With #endNewline) str
-        located t p_hsType
-      else do
-        located t p_hsType
-        newline
-        p_hsDoc Caret (Without #endNewline) str
+    withHaddocks (Is #end) (Just str) $ do
+      located t p_hsType
   HsBangTy _ (HsBang u s) t -> do
     case u of
       SrcUnpack -> txt "{-# UNPACK #-}" >> space
@@ -215,83 +197,6 @@ hasDocStrings = \case
 p_hsContext :: HsContext GhcPs -> R ()
 p_hsContext = p_hsContext' p_hsType
 
-p_hsContext' ::
-  (Outputable (GenLocated (Anno a) a), HasLoc (Anno a)) =>
-  (a -> R ()) ->
-  [XRec GhcPs a] ->
-  R ()
-p_hsContext' f = \case
-  [] -> txt "()"
-  [x] -> located x f
-  xs -> do
-    shouldSort <- getPrinterOpt poSortConstraints
-    let sort = if shouldSort then sortOn showOutputable else id
-    parens N $ sep commaDel (sitcc . located' f) (sort xs)
-
-class IsTyVarBndrFlag flag where
-  isInferred :: flag -> Bool
-  p_tyVarBndrFlag :: flag -> R ()
-  p_tyVarBndrFlag _ = pure ()
-
-instance IsTyVarBndrFlag () where
-  isInferred () = False
-
-instance IsTyVarBndrFlag Specificity where
-  isInferred = \case
-    InferredSpec -> True
-    SpecifiedSpec -> False
-
-instance IsTyVarBndrFlag (HsBndrVis GhcPs) where
-  isInferred _ = False
-  p_tyVarBndrFlag = \case
-    HsBndrRequired NoExtField -> pure ()
-    HsBndrInvisible _ -> txt "@"
-
-p_hsTyVarBndr :: (IsTyVarBndrFlag flag) => HsTyVarBndr flag GhcPs -> R ()
-p_hsTyVarBndr HsTvb {..} = do
-  p_tyVarBndrFlag tvb_flag
-  let wrap
-        | isInferred tvb_flag = braces N
-        | otherwise = case tvb_kind of
-            HsBndrKind {} -> parens N
-            HsBndrNoKind {} -> id
-  wrap $ do
-    case tvb_var of
-      HsBndrVar _ x -> p_rdrName x
-      HsBndrWildCard _ -> txt "_"
-    case tvb_kind of
-      HsBndrKind _ k -> inci $ p_hsTypeAnnotation k
-      HsBndrNoKind _ -> pure ()
-
-data ForAllVisibility = ForAllInvis | ForAllVis
-
--- | Render several @forall@-ed variables.
-p_forallBndrs ::
-  (HasLoc l) =>
-  ForAllVisibility ->
-  (a -> R ()) ->
-  [GenLocated l a] ->
-  R ()
-p_forallBndrs vis p tyvars = do
-  p_forallBndrsStart p tyvars
-  p_forallBndrsEnd (Without #extraSpace) vis
-
-p_forallBndrsStart :: (HasLoc l) => (a -> R ()) -> [GenLocated l a] -> R ()
-p_forallBndrsStart _ [] = token'forall
-p_forallBndrsStart p tyvars = do
-  switchLayout (locA <$> tyvars) $ do
-    token'forall
-    breakpoint
-    inci $ do
-      sitcc $ sep breakpoint (sitcc . located' p) tyvars
-
-p_forallBndrsEnd :: Choice "extraSpace" -> ForAllVisibility -> R ()
-p_forallBndrsEnd extraSpace = \case
-  ForAllInvis -> txt dot >> space
-  ForAllVis -> space >> token'rarrow
-  where
-    dot = if Choice.isTrue extraSpace then " ." else "."
-
 p_conDeclFields :: [LConDeclField GhcPs] -> R ()
 p_conDeclFields xs =
   recordBraces $ sep commaDel (sitcc . located' p_conDeclField) xs
@@ -322,54 +227,32 @@ p_lhsTypeArg = \case
 p_hsSigType :: HsSigType GhcPs -> R ()
 p_hsSigType = p_hsType . hsSigTypeToType
 
-----------------------------------------------------------------------------
--- Rendering function types
-
--- | The parsed representation of a function
-data ParsedFunRepr a
-  = ParsedFunSig (ParsedFunRepr a)
-  | ParsedFunForall
-      (LocatedA (HsForAllTelescope GhcPs))
-      (ParsedFunRepr a)
-  | ParsedFunQuals
-      [LocatedA (LocatedC [LocatedA a])]
-      (ParsedFunRepr a)
-  | -- | The argument, its optional docstring, and the arrow going to the next arg/return
-    ParsedFunArgs
-      [ LocatedA
-          ( LocatedA a,
-            Maybe (LHsDoc GhcPs),
-            HsArrowOf (LocatedA a) GhcPs
-          )
-      ]
-      (ParsedFunRepr a)
-  | ParsedFunReturn
-      ( LocatedA a,
-        Maybe (LHsDoc GhcPs)
-      )
-
-class (Anno a ~ SrcSpanAnnA, Outputable a) => FunRepr a where
-  renderFunItem :: a -> R ()
-
-  parseFunRepr :: LocatedA a -> ParsedFunRepr a
-
 instance FunRepr (HsType GhcPs) where
   renderFunItem = p_hsType
   parseFunRepr = \case
     -- `forall a. _`
     L ann (HsForAllTy _ tele ty) ->
-      ParsedFunForall (L ann tele) (parseFunRepr ty)
+      ParsedFunForall {tele = L ann tele, next = parseFunRepr ty}
     -- `HasCallStack => _`
     ty@(L _ HsQualTy {}) ->
       let (ctxs, rest) = getContexts ty
-       in ParsedFunQuals ctxs (parseFunRepr rest)
+       in ParsedFunQuals {ctxs, next = parseFunRepr rest}
     -- `Int -> _`
-    ty@(L _ HsFunTy {}) ->
-      let (args, ret) = getArgsAndReturn ty
-       in ParsedFunArgs args (parseFunRepr ret)
+    L ann (HsFunTy _ arrow l r) ->
+      let (item, doc) =
+            case l of
+              L _ (HsDocTy _ x doc_) -> (x, Just doc_)
+              _ -> (l, Nothing)
+       in ParsedFunArg
+            { span = ann,
+              item,
+              doc,
+              arrow,
+              next = parseFunRepr r
+            }
     -- `_ -> Int`
-    L _ (HsDocTy _ ty doc) -> ParsedFunReturn (ty, Just doc)
-    ty -> ParsedFunReturn (ty, Nothing)
+    L _ (HsDocTy _ ty doc) -> ParsedFunReturn {item = ty, doc = Just doc}
+    ty -> ParsedFunReturn {item = ty, doc = Nothing}
     where
       getContexts =
         let go ctxs = \case
@@ -378,203 +261,6 @@ instance FunRepr (HsType GhcPs) where
               ty ->
                 (reverse ctxs, ty)
          in go []
-      getArgsAndReturn =
-        let go args = \case
-              L ann (HsFunTy _ arrow (L _ (HsDocTy _ l doc)) r) ->
-                go (L ann (l, Just doc, arrow) : args) r
-              L ann (HsFunTy _ arrow l r) ->
-                go (L ann (l, Nothing, arrow) : args) r
-              ty ->
-                (reverse args, ty)
-         in go []
-
--- | For implementing function-arrows and related configuration, we'll collect
--- all the components of the function type first, then render as a block instead
--- of rendering each part independently, which will let us track local state
--- within a function type.
---
--- This function should be passed the first function-related construct we find;
--- see FunRepr for more details.
-p_hsFun :: (FunRepr a) => a -> R ()
-p_hsFun = p_hsFunParsed . parseFunRepr . L (noAnn @SrcSpanAnnA)
-
-p_hsFunParsed :: (FunRepr a) => ParsedFunRepr a -> R ()
-p_hsFunParsed fun = do
-  arrowsStyle <- getPrinterOpt poFunctionArrows
-  p_hsFunParsed' arrowsStyle fun
-
-type PrintHsFun x = State.StateT PrintHsFunState (Cont.ContT () R) x
-
-type PrintHsFunState =
-  ( Maybe (R ()), -- The leading delimiter to output at the next line
-    Choice "forceMultiline"
-  )
-
-p_hsFunParsed' ::
-  (FunRepr a) =>
-  FunctionArrowsStyle ->
-  ParsedFunRepr a ->
-  R ()
-p_hsFunParsed' arrowsStyle fun0 = Cont.evalContT . (`State.evalStateT` initialState) . go $ fun0
-  where
-    go = \case
-      ParsedFunSig fun' -> do
-        -- Should only happen at the very beginning, if at all
-        p_parsedFunSig
-        setMultilineContext fun'
-        go fun'
-      ParsedFunForall tele fun' -> do
-        p_parsedFunForall tele
-        setMultilineContext fun'
-        go fun'
-      ParsedFunQuals ctxs fun' -> do
-        p_parsedFunQuals ctxs
-        setMultilineContext fun'
-        go fun'
-      ParsedFunArgs args fun' -> do
-        p_parsedFunArgs args
-        go fun'
-      ParsedFunReturn ret -> do
-        p_parsedFunReturn ret
-
-    liftR = Trans.lift . Trans.lift
-    initialState = (Nothing, Without #forceMultiline)
-
-    withApplyLeadingDelim f = do
-      (leadingDelim, _) <- State.get
-      a <- f leadingDelim
-      State.modify $ \(_, x) -> (Nothing, x)
-      pure a
-    applyLeadingDelim = withApplyLeadingDelim (traverse_ liftR)
-
-    setLeadingDelim delim =
-      State.modify $ \(_, x) -> (Just delim, x)
-
-    getIsMultiline = do
-      (_, forceMultiline) <- State.get
-      layout <- liftR getLayout
-      pure $ Choice.toBool forceMultiline || layout == MultiLine
-
-    setMultilineContext fun =
-      State.modify $ \(x, _) -> (x, Choice.fromBool $ hasDocs fun)
-
-    -- Make everything afterwards occur within a located block, with the
-    -- magic of ContT. `item <- setLocated litem; ...` is equivalent to
-    -- `located litem $ \item -> ...`.
-    setLocated :: (HasLoc ann) => GenLocated ann x -> PrintHsFun x
-    setLocated litem = Trans.lift $ Cont.ContT (located litem)
-
-    p_parsedFunSig = do
-      if isTrailing (Isn't #argDelim)
-        then liftR $ do
-          space >> token'dcolon
-          if hasDocs fun0 then newline else breakpoint
-        else do
-          liftR breakpoint
-          setLeadingDelim (token'dcolon >> space)
-
-    p_parsedFunForall x@(L _ tele) = do
-      void $ setLocated x
-      applyLeadingDelim
-      vis <-
-        case tele of
-          HsForAllInvis _ bndrs -> do
-            liftR $ p_forallBndrsStart p_hsTyVarBndr bndrs
-            pure ForAllInvis
-          HsForAllVis _ bndrs -> do
-            liftR $ p_forallBndrsStart p_hsTyVarBndr bndrs
-            pure ForAllVis
-      isMultiline <- getIsMultiline
-      if isTrailing (Isn't #argDelim) || not isMultiline
-        then do
-          liftR $ p_forallBndrsEnd (Without #extraSpace) vis
-          interArgBreak
-        else do
-          interArgBreak
-          let extraSpace = if isMultiline then With #extraSpace else Without #extraSpace
-          setLeadingDelim (p_forallBndrsEnd extraSpace vis)
-
-    p_parsedFunQuals ctxs = do
-      -- we only want to set located on the first context
-      case ctxs of
-        ctx : _ -> void $ setLocated ctx
-        _ -> pure ()
-
-      forM_ ctxs $ \(L _ lctx) -> do
-        applyLeadingDelim
-        liftR $ located lctx (p_hsContext' renderFunItem)
-        if isTrailing (Isn't #argDelim)
-          then do
-            liftR $ space >> token'darrow
-            interArgBreak
-          else do
-            interArgBreak
-            setLeadingDelim (token'darrow >> space)
-
-    p_parsedFunArgs args = do
-      -- we only want to set located on the first arg
-      case args of
-        arg : _ -> void $ setLocated arg
-        _ -> pure ()
-
-      forM_ args $ \(L _ (larg, doc, arrow)) -> do
-        let renderArrow = p_arrow (located' renderFunItem) arrow
-        withHaddocks (Isn't #end) doc $ do
-          withApplyLeadingDelim $ \applyLeadingDelim' ->
-            liftR . located larg $ \arg -> do
-              traverse_ id applyLeadingDelim'
-              renderFunItem arg
-          if isTrailing (Is #argDelim)
-            then do
-              liftR $ space >> renderArrow
-              interArgBreak
-            else do
-              interArgBreak
-              setLeadingDelim (renderArrow >> space)
-
-    p_parsedFunReturn (ret, doc) = do
-      void $ setLocated ret
-      withHaddocks (Is #end) doc $ do
-        applyLeadingDelim
-        liftR $ located ret renderFunItem
-
-    withHaddocks isEnd doc m = do
-      isLeadingHaddock <-
-        liftR $
-          getPrinterOpt poHaddockLocSignature <&> \case
-            HaddockLocSigAuto ->
-              if isTrailing (Is #argDelim) then With #pipe else Without #pipe
-            HaddockLocSigLeading ->
-              With #pipe
-            HaddockLocSigTrailing ->
-              Without #pipe
-
-      if Choice.isTrue isLeadingHaddock
-        then do
-          traverse (liftR . p_hsDoc Pipe (With #endNewline)) doc *> m
-        else do
-          let (pre, endNewline) =
-                if Choice.isTrue isEnd
-                  then (when (isJust doc) (liftR newline), Without #endNewline)
-                  else (pure (), With #endNewline)
-          m <* pre <* traverse (liftR . p_hsDoc Caret endNewline) doc
-
-    interArgBreak = do
-      isMultiline <- getIsMultiline
-      liftR $ if isMultiline then newline else breakpoint
-
-    hasDocs = \case
-      ParsedFunSig fun -> hasDocs fun
-      ParsedFunForall _ fun -> hasDocs fun
-      ParsedFunQuals _ fun -> hasDocs fun
-      ParsedFunArgs args fun -> or [isJust doc | L _ (_, doc, _) <- args] || hasDocs fun
-      ParsedFunReturn (_, doc) -> isJust doc
-
-    isTrailing isArgDelim =
-      case arrowsStyle of
-        TrailingArrows -> True
-        LeadingArgsArrows -> not $ Choice.isTrue isArgDelim
-        LeadingArrows -> False
 
 ----------------------------------------------------------------------------
 -- Conversion functions

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -212,18 +212,21 @@ p_conDeclFields xs =
   recordBraces $ sep commaDel (sitcc . located' p_conDeclField) xs
 
 p_conDeclField :: ConDeclField GhcPs -> R ()
-p_conDeclField ConDeclField {..} = do
-  commaStyle <- getPrinterOpt poCommaStyle
-  when (commaStyle == Trailing) $
-    mapM_ (p_hsDoc Pipe (With #endNewline)) cd_fld_doc
+p_conDeclField ConDeclField {..} = withFieldHaddocks $ do
   sitcc $
     sep
       commaDel
       (located' (p_rdrName . foLabel))
       cd_fld_names
   inci $ p_hsTypeAnnotation cd_fld_type
-  when (commaStyle == Leading) $
-    mapM_ (inciByFrac (-1) . (newline >>) . p_hsDoc Caret (Without #endNewline)) cd_fld_doc
+  where
+    withFieldHaddocks action = do
+      commaStyle <- getPrinterOpt poCommaStyle
+      when (commaStyle == Trailing) $
+        mapM_ (p_hsDoc Pipe (With #endNewline)) cd_fld_doc
+      action
+      when (commaStyle == Leading) $
+        mapM_ (inciByFrac (-1) . (newline >>) . p_hsDoc Caret (Without #endNewline)) cd_fld_doc
 
 p_lhsTypeArg :: LHsTypeArg GhcPs -> R ()
 p_lhsTypeArg = \case

--- a/src/Ormolu/Printer/Meat/Type.hs
+++ b/src/Ormolu/Printer/Meat/Type.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -20,12 +21,15 @@ module Ormolu.Printer.Meat.Type
     p_conDeclFields,
     p_lhsTypeArg,
     p_hsSigType,
-    FunRepr (..),
-    ParsedFunRepr (..),
-    p_hsFun,
     hsOuterTyVarBndrsToHsType,
     hsSigTypeToType,
     lhsTypeToSigType,
+
+    -- * Re-exports from Ormolu.Printer.Meat.Type.Function
+    FunRepr (..),
+    ParsedFunRepr,
+    ParsedFunRepr' (..),
+    p_hsFun,
   )
 where
 
@@ -45,6 +49,7 @@ import {-# SOURCE #-} Ormolu.Printer.Meat.Declaration.Value (p_hsUntypedSplice)
 import Ormolu.Printer.Meat.Type.Function
 import Ormolu.Printer.Operators
 import Ormolu.Utils
+import Prelude hiding (span)
 
 p_hsType :: HsType GhcPs -> R ()
 p_hsType = \case
@@ -182,7 +187,12 @@ p_hsType = \case
       _ -> False
 
 p_hsTypeAnnotation :: LHsType GhcPs -> R ()
-p_hsTypeAnnotation = p_hsFunParsed . ParsedFunSig . parseFunRepr
+p_hsTypeAnnotation ty =
+  p_hsFunParsed @(HsType GhcPs) $
+    ParsedFunSig
+      { sig = (),
+        next = parseFunRepr ty
+      }
 
 -- | Return 'True' if at least one argument in 'HsType' has a doc string
 -- attached to it.
@@ -228,31 +238,36 @@ p_hsSigType :: HsSigType GhcPs -> R ()
 p_hsSigType = p_hsType . hsSigTypeToType
 
 instance FunRepr (HsType GhcPs) where
-  renderFunItem = p_hsType
   parseFunRepr = \case
     -- `forall a. _`
     L ann (HsForAllTy _ tele ty) ->
-      ParsedFunForall {tele = L ann tele, next = parseFunRepr ty}
+      ParsedFunForall
+        { tele = L ann tele,
+          next = parseFunRepr ty
+        }
     -- `HasCallStack => _`
     ty@(L _ HsQualTy {}) ->
       let (ctxs, rest) = getContexts ty
-       in ParsedFunQuals {ctxs, next = parseFunRepr rest}
+       in ParsedFunQuals
+            { ctxs,
+              next = parseFunRepr rest
+            }
     -- `Int -> _`
     L ann (HsFunTy _ arrow l r) ->
-      let (item, doc) =
+      let (arg, doc) =
             case l of
               L _ (HsDocTy _ x doc_) -> (x, Just doc_)
               _ -> (l, Nothing)
        in ParsedFunArg
             { span = ann,
-              item,
+              arg,
               doc,
               arrow,
               next = parseFunRepr r
             }
     -- `_ -> Int`
-    L _ (HsDocTy _ ty doc) -> ParsedFunReturn {item = ty, doc = Just doc}
-    ty -> ParsedFunReturn {item = ty, doc = Nothing}
+    L _ (HsDocTy _ ret doc) -> ParsedFunReturn {ret, doc = Just doc}
+    ret -> ParsedFunReturn {ret, doc = Nothing}
     where
       getContexts =
         let go ctxs = \case
@@ -261,6 +276,11 @@ instance FunRepr (HsType GhcPs) where
               ty ->
                 (reverse ctxs, ty)
          in go []
+
+  renderFunReprCtx = p_hsType
+  renderFunReprArg = p_hsType
+  renderFunReprArr = p_hsType
+  renderFunReprRet = p_hsType
 
 ----------------------------------------------------------------------------
 -- Conversion functions

--- a/src/Ormolu/Printer/Meat/Type/Function.hs
+++ b/src/Ormolu/Printer/Meat/Type/Function.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
@@ -6,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
 -- | A Fourmolu-specific module for rendering function-like type signatures.
@@ -15,7 +18,8 @@ module Ormolu.Printer.Meat.Type.Function
     MonadR,
 
     -- * ParsedFunRepr
-    ParsedFunRepr (..),
+    ParsedFunRepr,
+    ParsedFunRepr' (..),
     FunRepr (..),
     p_hsFun,
     p_hsFunParsed,
@@ -107,7 +111,7 @@ getIsMultiline = do
   layout <- liftR getLayout
   pure $ state.forceMultiline || layout == MultiLine
 
-setMultilineContext :: ParsedFunRepr a -> PrintHsFun ()
+setMultilineContext :: ParsedFunRepr' sig ctx arg arr ret -> PrintHsFun ()
 setMultilineContext fun =
   PrintHsFun . State.modify $ \state -> state {forceMultiline = hasDocs fun}
 
@@ -137,39 +141,87 @@ setLocated_ = void . setLocated
 
 {----- ParsedFunRepr -----}
 
+type ParsedFunRepr a =
+  ParsedFunRepr'
+    (FunReprSig a)
+    (FunReprCtx a)
+    (FunReprArg a)
+    (FunReprArr a)
+    (FunReprRet a)
+
 -- | The parsed representation of a function
-data ParsedFunRepr a
+data ParsedFunRepr' sig ctx arg arr ret
   = -- | The "::" delimiter. Invariant: must be first.
     ParsedFunSig
-      { next :: ParsedFunRepr a
+      { sig :: sig,
+        next :: ParsedFunRepr' sig ctx arg arr ret
       }
   | -- | The "forall a b." or "forall a b ->" construct.
     ParsedFunForall
       { tele :: LocatedA (HsForAllTelescope GhcPs),
-        next :: ParsedFunRepr a
+        next :: ParsedFunRepr' sig ctx arg arr ret
       }
   | -- | The "(A, B) =>" construct.
     ParsedFunQuals
-      { ctxs :: [LocatedA (LocatedC [LocatedA a])],
-        next :: ParsedFunRepr a
+      { ctxs :: [LocatedA (LocatedC [LocatedA ctx])],
+        next :: ParsedFunRepr' sig ctx arg arr ret
       }
   | ParsedFunArg
       { span :: SrcSpanAnnA,
-        item :: LocatedA a,
+        arg :: LocatedA arg,
         doc :: Maybe (LHsDoc GhcPs),
-        arrow :: HsArrowOf (LocatedA a) GhcPs,
-        next :: ParsedFunRepr a
+        arrow :: HsArrowOf (LocatedA arr) GhcPs,
+        next :: ParsedFunRepr' sig ctx arg arr ret
       }
   | ParsedFunReturn
-      { item :: LocatedA a,
+      { ret :: LocatedA ret,
         doc :: Maybe (LHsDoc GhcPs)
       }
 
-class (Anno a ~ SrcSpanAnnA, Outputable a) => FunRepr a where
-  renderFunItem :: a -> R ()
+class
+  ( Anno (FunReprCtx a) ~ SrcSpanAnnA,
+    Outputable (FunReprCtx a)
+  ) =>
+  FunRepr a
+  where
   parseFunRepr :: LocatedA a -> ParsedFunRepr a
 
-hasDocs :: ParsedFunRepr a -> Bool
+  type FunReprSig a
+  type FunReprSig a = ()
+  renderFunReprSig :: FunReprSig a -> R ()
+  default renderFunReprSig :: (FunReprSig a ~ ()) => FunReprSig a -> R ()
+  renderFunReprSig () = space *> token'dcolon
+
+  type FunReprCtx a
+  type FunReprCtx a = a
+  renderFunReprCtx :: FunReprCtx a -> R ()
+
+  type FunReprArg a
+  type FunReprArg a = a
+  renderFunReprArg :: FunReprArg a -> R ()
+
+  type FunReprArr a
+  type FunReprArr a = a
+  renderFunReprArr :: FunReprArr a -> R ()
+
+  type FunReprRet a
+  type FunReprRet a = a
+  renderFunReprRet :: FunReprRet a -> R ()
+
+-- | Some functions rely on HsType having a FunRepr instance, but the instance
+-- can't be implemented here, since p_hsType is implemented in Type.hs, which
+-- would cause a circular dependency. So we'll add it as an explicit constraint
+-- and the call-site should bring the FunRepr instance for HsType in scope.
+type FunReprHsType =
+  ( FunRepr (HsType GhcPs),
+    FunReprSig (HsType GhcPs) ~ (),
+    FunReprCtx (HsType GhcPs) ~ HsType GhcPs,
+    FunReprArg (HsType GhcPs) ~ HsType GhcPs,
+    FunReprArr (HsType GhcPs) ~ HsType GhcPs,
+    FunReprRet (HsType GhcPs) ~ HsType GhcPs
+  )
+
+hasDocs :: ParsedFunRepr' ig ctx arg arr ret -> Bool
 hasDocs = \case
   ParsedFunSig {next} -> hasDocs next
   ParsedFunForall {next} -> hasDocs next
@@ -186,29 +238,29 @@ hasDocs = \case
 --
 -- This function should be passed the first function-related construct we find;
 -- see FunRepr for more details.
-p_hsFun :: (FunRepr a, FunRepr (HsType GhcPs)) => a -> R ()
-p_hsFun = p_hsFunParsed . parseFunRepr . L (noAnn @SrcSpanAnnA)
+p_hsFun :: forall a. (FunRepr a, FunReprHsType) => a -> R ()
+p_hsFun = p_hsFunParsed @a . parseFunRepr . L (noAnn @SrcSpanAnnA)
 
-p_hsFunParsed :: (FunRepr a, FunRepr (HsType GhcPs)) => ParsedFunRepr a -> R ()
-p_hsFunParsed = runPrintHsFun . p_hsFunParsed'
+p_hsFunParsed :: forall a. (FunRepr a, FunReprHsType) => ParsedFunRepr a -> R ()
+p_hsFunParsed = runPrintHsFun . p_hsFunParsed' @a
 
-p_hsFunParsed' :: (FunRepr a, FunRepr (HsType GhcPs)) => ParsedFunRepr a -> PrintHsFun ()
+p_hsFunParsed' :: forall a. (FunRepr a, FunReprHsType) => ParsedFunRepr a -> PrintHsFun ()
 p_hsFunParsed' = \case
-  ParsedFunSig {next} -> do
+  ParsedFunSig {sig, next} -> do
     -- Should only happen at the very beginning, if at all
-    p_parsedFunSig next
+    p_parsedFunSig @a sig next
     setMultilineContext next
-    p_hsFunParsed' next
+    p_hsFunParsed' @a next
   ParsedFunForall {tele, next} -> do
     p_parsedFunForall tele
     setMultilineContext next
-    p_hsFunParsed' next
+    p_hsFunParsed' @a next
   ParsedFunQuals {ctxs, next} -> do
-    p_parsedFunQuals ctxs
+    p_parsedFunQuals @a ctxs
     setMultilineContext next
-    p_hsFunParsed' next
-  ParsedFunArg {span, item, doc, arrow, next} -> do
-    p_parsedFunArg span item doc arrow
+    p_hsFunParsed' @a next
+  ParsedFunArg {span, arg, doc, arrow, next} -> do
+    p_parsedFunArg @a span arg doc arrow
     case next of
       ParsedFunArg {} -> pure ()
       _ -> do
@@ -218,22 +270,22 @@ p_hsFunParsed' = \case
         -- Reset inArgList, needed if there are multiple arg lists in one
         -- function type (e.g. `a -> Show a => b -> c`)
         setInArgList False
-    p_hsFunParsed' next
-  ParsedFunReturn {item, doc} -> do
-    p_parsedFunReturn item doc
+    p_hsFunParsed' @a next
+  ParsedFunReturn {ret, doc} -> do
+    p_parsedFunReturn @a ret doc
 
-p_parsedFunSig :: ParsedFunRepr a -> PrintHsFun ()
-p_parsedFunSig fun = do
+p_parsedFunSig :: forall a. (FunRepr a) => FunReprSig a -> ParsedFunRepr a -> PrintHsFun ()
+p_parsedFunSig sig fun = do
   isTrailing <- getIsTrailing
   if isTrailing (Isn't #argDelim)
     then liftR $ do
-      space >> token'dcolon
+      renderFunReprSig @a sig
       if hasDocs fun then newline else breakpoint
     else do
       liftR breakpoint
       setLeadingDelim (token'dcolon >> space)
 
-p_parsedFunForall :: (FunRepr (HsType GhcPs)) => LocatedA (HsForAllTelescope GhcPs) -> PrintHsFun ()
+p_parsedFunForall :: (FunReprHsType) => LocatedA (HsForAllTelescope GhcPs) -> PrintHsFun ()
 p_parsedFunForall x@(L _ tele) = do
   setLocated_ x
   applyLeadingDelim
@@ -257,7 +309,7 @@ p_parsedFunForall x@(L _ tele) = do
       let extraSpace = if isMultiline then With #extraSpace else Without #extraSpace
       setLeadingDelim (p_forallBndrsEnd extraSpace vis)
 
-p_parsedFunQuals :: (FunRepr a) => [LocatedA (LocatedC [LocatedA a])] -> PrintHsFun ()
+p_parsedFunQuals :: forall a. (FunRepr a) => [LocatedA (LocatedC [LocatedA (FunReprCtx a)])] -> PrintHsFun ()
 p_parsedFunQuals ctxs = do
   isTrailing <- getIsTrailing
   -- we only want to set located on the first context
@@ -267,7 +319,7 @@ p_parsedFunQuals ctxs = do
 
   forM_ ctxs $ \(L _ lctx) -> do
     applyLeadingDelim
-    liftR $ located lctx (p_hsContext' renderFunItem)
+    liftR $ located lctx (p_hsContext' (renderFunReprCtx @a))
     if isTrailing (Isn't #argDelim)
       then do
         liftR $ space >> token'darrow
@@ -277,11 +329,12 @@ p_parsedFunQuals ctxs = do
         setLeadingDelim (token'darrow >> space)
 
 p_parsedFunArg ::
+  forall a.
   (FunRepr a) =>
   SrcSpanAnnA ->
-  LocatedA a ->
+  LocatedA (FunReprArg a) ->
   Maybe (LHsDoc GhcPs) ->
-  HsArrowOf (LocatedA a) GhcPs ->
+  HsArrowOf (LocatedA (FunReprArr a)) GhcPs ->
   PrintHsFun ()
 p_parsedFunArg span item doc arrow = do
   isTrailing <- getIsTrailing
@@ -292,12 +345,12 @@ p_parsedFunArg span item doc arrow = do
     setLocated_ (L span item)
     setInArgList True
 
-  let renderArrow = p_arrow (located' renderFunItem) arrow
+  let renderArrow = p_arrow (located' (renderFunReprArr @a)) arrow
   withHaddocks (Isn't #end) doc $ do
     withApplyLeadingDelim $ \applyLeadingDelim' ->
       liftR . located item $ \arg -> do
         traverse_ id applyLeadingDelim'
-        renderFunItem arg
+        renderFunReprArg @a arg
     if isTrailing (Is #argDelim)
       then do
         liftR $ space >> renderArrow
@@ -306,12 +359,17 @@ p_parsedFunArg span item doc arrow = do
         interArgBreak
         setLeadingDelim (renderArrow >> space)
 
-p_parsedFunReturn :: (FunRepr a) => LocatedA a -> Maybe (LHsDoc GhcPs) -> PrintHsFun ()
+p_parsedFunReturn ::
+  forall a.
+  (FunRepr a) =>
+  LocatedA (FunReprRet a) ->
+  Maybe (LHsDoc GhcPs) ->
+  PrintHsFun ()
 p_parsedFunReturn item doc = do
   setLocated_ item
   withHaddocks (Is #end) doc $ do
     applyLeadingDelim
-    liftR $ located item renderFunItem
+    liftR $ located item (renderFunReprRet @a)
 
 {----- forall -----}
 
@@ -366,7 +424,7 @@ instance IsTyVarBndrFlag (HsBndrVis GhcPs) where
     HsBndrInvisible _ -> txt "@"
 
 p_hsTyVarBndr ::
-  (IsTyVarBndrFlag flag, FunRepr (HsType GhcPs)) =>
+  (IsTyVarBndrFlag flag, FunReprHsType) =>
   HsTyVarBndr flag GhcPs -> R ()
 p_hsTyVarBndr HsTvb {..} = do
   p_tyVarBndrFlag tvb_flag
@@ -380,7 +438,12 @@ p_hsTyVarBndr HsTvb {..} = do
       HsBndrVar _ x -> p_rdrName x
       HsBndrWildCard _ -> txt "_"
     case tvb_kind of
-      HsBndrKind _ k -> inci $ (p_hsFunParsed . ParsedFunSig . parseFunRepr) k
+      HsBndrKind _ k -> inci $ do
+        p_hsFunParsed @(HsType GhcPs) $
+          ParsedFunSig
+            { sig = (),
+              next = parseFunRepr k
+            }
       HsBndrNoKind _ -> pure ()
 
 {----- Contexts -----}

--- a/src/Ormolu/Printer/Meat/Type/Function.hs
+++ b/src/Ormolu/Printer/Meat/Type/Function.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoFieldSelectors #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
 
 -- | A Fourmolu-specific module for rendering function-like type signatures.
 module Ormolu.Printer.Meat.Type.Function

--- a/src/Ormolu/Printer/Meat/Type/Function.hs
+++ b/src/Ormolu/Printer/Meat/Type/Function.hs
@@ -1,0 +1,429 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+-- | A Fourmolu-specific module for rendering function-like type signatures.
+module Ormolu.Printer.Meat.Type.Function
+  ( -- * PrintHsFun
+    PrintHsFun,
+    MonadR,
+
+    -- * ParsedFunRepr
+    ParsedFunRepr (..),
+    FunRepr (..),
+    p_hsFun,
+    p_hsFunParsed,
+
+    -- * forall
+    ForAllVisibility (..),
+    p_forallBndrs,
+
+    -- * TyVarBndr
+    p_hsTyVarBndr,
+
+    -- * Contexts
+    p_hsContext',
+
+    -- * Haddocks
+    withHaddocks,
+  )
+where
+
+import Control.Monad (forM_, void, when)
+import Control.Monad.Cont qualified as Cont
+import Control.Monad.State qualified as State
+import Control.Monad.Trans qualified as Trans
+import Data.Choice (Choice, pattern Is, pattern Isn't, pattern With, pattern Without)
+import Data.Choice qualified as Choice
+import Data.Foldable (traverse_)
+import Data.Functor ((<&>))
+import Data.List (sortOn)
+import Data.Maybe (isJust)
+import GHC.Hs
+import GHC.Types.SrcLoc (GenLocated (..))
+import GHC.Types.Var (Specificity (..))
+import GHC.Utils.Outputable (Outputable)
+import Ormolu.Config
+import Ormolu.Printer.Combinators
+import Ormolu.Printer.Meat.Common (p_arrow, p_hsDoc, p_rdrName)
+import Ormolu.Utils (showOutputable)
+import Prelude hiding (span)
+
+{----- PrintHsFun -----}
+
+newtype PrintHsFun a = PrintHsFun (State.StateT PrintHsFunState (Cont.ContT () R) a)
+  deriving newtype (Functor, Applicative, Monad)
+
+data PrintHsFunState = PrintHsFunState
+  { -- | The leading delimiter to output at the next line
+    leadingDelim :: Maybe (R ()),
+    forceMultiline :: Bool,
+    -- | Whether we're currently printing args
+    inArgList :: Bool
+  }
+
+runPrintHsFun :: PrintHsFun () -> R ()
+runPrintHsFun (PrintHsFun m) = Cont.evalContT . (`State.evalStateT` initialState) $ m
+  where
+    initialState =
+      PrintHsFunState
+        { leadingDelim = Nothing,
+          forceMultiline = False,
+          inArgList = False
+        }
+
+class (Monad m) => MonadR m where
+  liftR :: R a -> m a
+
+instance MonadR R where
+  liftR = id
+
+instance MonadR PrintHsFun where
+  liftR = PrintHsFun . Trans.lift . Trans.lift
+
+withApplyLeadingDelim :: (Maybe (R ()) -> PrintHsFun a) -> PrintHsFun a
+withApplyLeadingDelim f = do
+  state <- PrintHsFun State.get
+  a <- f state.leadingDelim
+  PrintHsFun . State.put $ state {leadingDelim = Nothing}
+  pure a
+
+applyLeadingDelim :: PrintHsFun ()
+applyLeadingDelim = withApplyLeadingDelim (traverse_ liftR)
+
+setLeadingDelim :: R () -> PrintHsFun ()
+setLeadingDelim delim =
+  PrintHsFun . State.modify $ \state -> state {leadingDelim = Just delim}
+
+getIsMultiline :: PrintHsFun Bool
+getIsMultiline = do
+  state <- PrintHsFun State.get
+  layout <- liftR getLayout
+  pure $ state.forceMultiline || layout == MultiLine
+
+setMultilineContext :: ParsedFunRepr a -> PrintHsFun ()
+setMultilineContext fun =
+  PrintHsFun . State.modify $ \state -> state {forceMultiline = hasDocs fun}
+
+getIsTrailing :: (MonadR m) => m (Choice "argDelim" -> Bool)
+getIsTrailing = do
+  arrowsStyle <- liftR $ getPrinterOpt poFunctionArrows
+  pure $ \isArgDelim ->
+    case arrowsStyle of
+      TrailingArrows -> True
+      LeadingArgsArrows -> not $ Choice.isTrue isArgDelim
+      LeadingArrows -> False
+
+getInArgList :: PrintHsFun Bool
+getInArgList = PrintHsFun . State.gets $ (.inArgList)
+
+setInArgList :: Bool -> PrintHsFun ()
+setInArgList x = PrintHsFun . State.modify $ \state -> state {inArgList = x}
+
+-- Make everything afterwards occur within a located block, with the
+-- magic of ContT. `item <- setLocated litem; ...` is equivalent to
+-- `located litem $ \item -> ...`.
+setLocated :: (HasLoc ann) => GenLocated ann x -> PrintHsFun x
+setLocated litem = PrintHsFun . Trans.lift $ Cont.ContT (located litem)
+
+setLocated_ :: (HasLoc ann) => GenLocated ann x -> PrintHsFun ()
+setLocated_ = void . setLocated
+
+{----- ParsedFunRepr -----}
+
+-- | The parsed representation of a function
+data ParsedFunRepr a
+  = -- | The "::" delimiter. Invariant: must be first.
+    ParsedFunSig
+      { next :: ParsedFunRepr a
+      }
+  | -- | The "forall a b." or "forall a b ->" construct.
+    ParsedFunForall
+      { tele :: LocatedA (HsForAllTelescope GhcPs),
+        next :: ParsedFunRepr a
+      }
+  | -- | The "(A, B) =>" construct.
+    ParsedFunQuals
+      { ctxs :: [LocatedA (LocatedC [LocatedA a])],
+        next :: ParsedFunRepr a
+      }
+  | ParsedFunArg
+      { span :: SrcSpanAnnA,
+        item :: LocatedA a,
+        doc :: Maybe (LHsDoc GhcPs),
+        arrow :: HsArrowOf (LocatedA a) GhcPs,
+        next :: ParsedFunRepr a
+      }
+  | ParsedFunReturn
+      { item :: LocatedA a,
+        doc :: Maybe (LHsDoc GhcPs)
+      }
+
+class (Anno a ~ SrcSpanAnnA, Outputable a) => FunRepr a where
+  renderFunItem :: a -> R ()
+  parseFunRepr :: LocatedA a -> ParsedFunRepr a
+
+hasDocs :: ParsedFunRepr a -> Bool
+hasDocs = \case
+  ParsedFunSig {next} -> hasDocs next
+  ParsedFunForall {next} -> hasDocs next
+  ParsedFunQuals {next} -> hasDocs next
+  ParsedFunArg {doc, next} -> isJust doc || hasDocs next
+  ParsedFunReturn {doc} -> isJust doc
+
+{----- Rendering ParsedFunRepr -----}
+
+-- | For implementing function-arrows and related configuration, we'll collect
+-- all the components of the function type first, then render as a block instead
+-- of rendering each part independently, which will let us track local state
+-- within a function type.
+--
+-- This function should be passed the first function-related construct we find;
+-- see FunRepr for more details.
+p_hsFun :: (FunRepr a, FunRepr (HsType GhcPs)) => a -> R ()
+p_hsFun = p_hsFunParsed . parseFunRepr . L (noAnn @SrcSpanAnnA)
+
+p_hsFunParsed :: (FunRepr a, FunRepr (HsType GhcPs)) => ParsedFunRepr a -> R ()
+p_hsFunParsed = runPrintHsFun . p_hsFunParsed'
+
+p_hsFunParsed' :: (FunRepr a, FunRepr (HsType GhcPs)) => ParsedFunRepr a -> PrintHsFun ()
+p_hsFunParsed' = \case
+  ParsedFunSig {next} -> do
+    -- Should only happen at the very beginning, if at all
+    p_parsedFunSig next
+    setMultilineContext next
+    p_hsFunParsed' next
+  ParsedFunForall {tele, next} -> do
+    p_parsedFunForall tele
+    setMultilineContext next
+    p_hsFunParsed' next
+  ParsedFunQuals {ctxs, next} -> do
+    p_parsedFunQuals ctxs
+    setMultilineContext next
+    p_hsFunParsed' next
+  ParsedFunArg {span, item, doc, arrow, next} -> do
+    p_parsedFunArg span item doc arrow
+    case next of
+      ParsedFunArg {} -> pure ()
+      _ -> do
+        -- Don't reset multiline context within args; all args should be on
+        -- one line together, or all on separate lines
+        setMultilineContext next
+        -- Reset inArgList, needed if there are multiple arg lists in one
+        -- function type (e.g. `a -> Show a => b -> c`)
+        setInArgList False
+    p_hsFunParsed' next
+  ParsedFunReturn {item, doc} -> do
+    p_parsedFunReturn item doc
+
+p_parsedFunSig :: ParsedFunRepr a -> PrintHsFun ()
+p_parsedFunSig fun = do
+  isTrailing <- getIsTrailing
+  if isTrailing (Isn't #argDelim)
+    then liftR $ do
+      space >> token'dcolon
+      if hasDocs fun then newline else breakpoint
+    else do
+      liftR breakpoint
+      setLeadingDelim (token'dcolon >> space)
+
+p_parsedFunForall :: (FunRepr (HsType GhcPs)) => LocatedA (HsForAllTelescope GhcPs) -> PrintHsFun ()
+p_parsedFunForall x@(L _ tele) = do
+  setLocated_ x
+  applyLeadingDelim
+  vis <-
+    case tele of
+      HsForAllInvis _ bndrs -> do
+        liftR $ p_forallBndrsStart p_hsTyVarBndr bndrs
+        pure ForAllInvis
+      HsForAllVis _ bndrs -> do
+        liftR $ p_forallBndrsStart p_hsTyVarBndr bndrs
+        pure ForAllVis
+
+  isTrailing <- getIsTrailing
+  isMultiline <- getIsMultiline
+  if isTrailing (Isn't #argDelim) || not isMultiline
+    then do
+      liftR $ p_forallBndrsEnd (Without #extraSpace) vis
+      interArgBreak
+    else do
+      interArgBreak
+      let extraSpace = if isMultiline then With #extraSpace else Without #extraSpace
+      setLeadingDelim (p_forallBndrsEnd extraSpace vis)
+
+p_parsedFunQuals :: (FunRepr a) => [LocatedA (LocatedC [LocatedA a])] -> PrintHsFun ()
+p_parsedFunQuals ctxs = do
+  isTrailing <- getIsTrailing
+  -- we only want to set located on the first context
+  case ctxs of
+    ctx : _ -> setLocated_ ctx
+    _ -> pure ()
+
+  forM_ ctxs $ \(L _ lctx) -> do
+    applyLeadingDelim
+    liftR $ located lctx (p_hsContext' renderFunItem)
+    if isTrailing (Isn't #argDelim)
+      then do
+        liftR $ space >> token'darrow
+        interArgBreak
+      else do
+        interArgBreak
+        setLeadingDelim (token'darrow >> space)
+
+p_parsedFunArg ::
+  (FunRepr a) =>
+  SrcSpanAnnA ->
+  LocatedA a ->
+  Maybe (LHsDoc GhcPs) ->
+  HsArrowOf (LocatedA a) GhcPs ->
+  PrintHsFun ()
+p_parsedFunArg span item doc arrow = do
+  isTrailing <- getIsTrailing
+
+  -- We only want to set located on the first arg
+  inArgList <- getInArgList
+  when (not inArgList) $ do
+    setLocated_ (L span item)
+    setInArgList True
+
+  let renderArrow = p_arrow (located' renderFunItem) arrow
+  withHaddocks (Isn't #end) doc $ do
+    withApplyLeadingDelim $ \applyLeadingDelim' ->
+      liftR . located item $ \arg -> do
+        traverse_ id applyLeadingDelim'
+        renderFunItem arg
+    if isTrailing (Is #argDelim)
+      then do
+        liftR $ space >> renderArrow
+        interArgBreak
+      else do
+        interArgBreak
+        setLeadingDelim (renderArrow >> space)
+
+p_parsedFunReturn :: (FunRepr a) => LocatedA a -> Maybe (LHsDoc GhcPs) -> PrintHsFun ()
+p_parsedFunReturn item doc = do
+  setLocated_ item
+  withHaddocks (Is #end) doc $ do
+    applyLeadingDelim
+    liftR $ located item renderFunItem
+
+{----- forall -----}
+
+data ForAllVisibility = ForAllInvis | ForAllVis
+
+-- | Render several @forall@-ed variables.
+p_forallBndrs ::
+  (HasLoc l) =>
+  ForAllVisibility ->
+  (a -> R ()) ->
+  [GenLocated l a] ->
+  R ()
+p_forallBndrs vis p tyvars = do
+  p_forallBndrsStart p tyvars
+  p_forallBndrsEnd (Without #extraSpace) vis
+
+p_forallBndrsStart :: (HasLoc l) => (a -> R ()) -> [GenLocated l a] -> R ()
+p_forallBndrsStart _ [] = token'forall
+p_forallBndrsStart p tyvars = do
+  switchLayout (locA <$> tyvars) $ do
+    token'forall
+    breakpoint
+    inci $ do
+      sitcc $ sep breakpoint (sitcc . located' p) tyvars
+
+p_forallBndrsEnd :: Choice "extraSpace" -> ForAllVisibility -> R ()
+p_forallBndrsEnd extraSpace = \case
+  ForAllInvis -> txt dot >> space
+  ForAllVis -> space >> token'rarrow
+  where
+    dot = if Choice.isTrue extraSpace then " ." else "."
+
+{----- HsTyVarBndr -----}
+
+class IsTyVarBndrFlag flag where
+  isInferred :: flag -> Bool
+  p_tyVarBndrFlag :: flag -> R ()
+  p_tyVarBndrFlag _ = pure ()
+
+instance IsTyVarBndrFlag () where
+  isInferred () = False
+
+instance IsTyVarBndrFlag Specificity where
+  isInferred = \case
+    InferredSpec -> True
+    SpecifiedSpec -> False
+
+instance IsTyVarBndrFlag (HsBndrVis GhcPs) where
+  isInferred _ = False
+  p_tyVarBndrFlag = \case
+    HsBndrRequired NoExtField -> pure ()
+    HsBndrInvisible _ -> txt "@"
+
+p_hsTyVarBndr ::
+  (IsTyVarBndrFlag flag, FunRepr (HsType GhcPs)) =>
+  HsTyVarBndr flag GhcPs -> R ()
+p_hsTyVarBndr HsTvb {..} = do
+  p_tyVarBndrFlag tvb_flag
+  let wrap
+        | isInferred tvb_flag = braces N
+        | otherwise = case tvb_kind of
+            HsBndrKind {} -> parens N
+            HsBndrNoKind {} -> id
+  wrap $ do
+    case tvb_var of
+      HsBndrVar _ x -> p_rdrName x
+      HsBndrWildCard _ -> txt "_"
+    case tvb_kind of
+      HsBndrKind _ k -> inci $ (p_hsFunParsed . ParsedFunSig . parseFunRepr) k
+      HsBndrNoKind _ -> pure ()
+
+{----- Contexts -----}
+
+p_hsContext' ::
+  (Outputable (GenLocated (Anno a) a), HasLoc (Anno a)) =>
+  (a -> R ()) ->
+  [XRec GhcPs a] ->
+  R ()
+p_hsContext' f = \case
+  [] -> txt "()"
+  [x] -> located x f
+  xs -> do
+    shouldSort <- getPrinterOpt poSortConstraints
+    let sort = if shouldSort then sortOn showOutputable else id
+    parens N $ sep commaDel (sitcc . located' f) (sort xs)
+
+{----- Helpers -----}
+
+withHaddocks :: (MonadR m) => Choice "end" -> Maybe (LHsDoc GhcPs) -> m a -> m a
+withHaddocks isEnd doc m = do
+  isTrailing <- getIsTrailing
+  isLeadingHaddock <-
+    liftR $
+      getPrinterOpt poHaddockLocSignature <&> \case
+        HaddockLocSigAuto ->
+          if isTrailing (Is #argDelim) then With #pipe else Without #pipe
+        HaddockLocSigLeading ->
+          With #pipe
+        HaddockLocSigTrailing ->
+          Without #pipe
+
+  if Choice.isTrue isLeadingHaddock
+    then do
+      traverse (liftR . p_hsDoc Pipe (With #endNewline)) doc *> m
+    else do
+      let (pre, endNewline) =
+            if Choice.isTrue isEnd
+              then (when (isJust doc) (liftR newline), Without #endNewline)
+              else (pure (), With #endNewline)
+      m <* pre <* traverse (liftR . p_hsDoc Caret endNewline) doc
+
+interArgBreak :: PrintHsFun ()
+interArgBreak = do
+  isMultiline <- getIsMultiline
+  liftR $ if isMultiline then newline else breakpoint


### PR DESCRIPTION
In preparation for https://github.com/fourmolu/fourmolu/pull/530, generalize `ParsedFunRepr` for cases where the things in the function (e.g. argument/return types) might not have the same type as the overall type. Then we can reuse this infrastructure for GADTs and, in GHC 9.14, for normal record field type annotations.