### PR TITLE
Allow empty config file

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,6 +18,7 @@ import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Set qualified as Set
 import Data.Text.IO.Utf8 qualified as T.Utf8
 import Data.Version (showVersion)
+import Data.Yaml (ParseException (..))
 import Data.Yaml qualified as Yaml
 import Distribution.ModuleName (ModuleName)
 import Distribution.Types.PackageName (PackageName)
@@ -95,6 +96,8 @@ resolveConfig opts@(Opts {optConfig = cliConfig, optPrinterOpts = cliPrinterOpts
         pure emptyConfig
       Right configPath ->
         Yaml.decodeFileEither configPath >>= \case
+          Left (AesonException "Error in $: parsing FourmoluConfig failed, expected Object, but encountered Null") -> do
+            pure emptyConfig
           Left e -> do
             outputError . unlines $
               [ "Failed to load " <> configPath <> ":",

--- a/tests/Ormolu/Integration/CLISpec.hs
+++ b/tests/Ormolu/Integration/CLISpec.hs
@@ -79,6 +79,17 @@ spec =
               }
         stdout `shouldBe` "f :: Show a => a -> String\n"
 
+    it "accepts empty config file" $ \fourmoluExe ->
+      withTempDir $ \tmpdir -> do
+        writeFile' (tmpdir </> "fourmolu.yaml") ""
+        stdout <-
+          readFrom $
+            (proc fourmoluExe ["--no-cabal", "-"])
+              { procStdin = unformattedCode,
+                procCwd = Just tmpdir
+              }
+        stdout `shouldBe` formattedCode
+
     it "recursively finds files in directories" $ \fourmoluExe -> do
       withTempDir $ \tmpdir -> do
         let hsFile = tmpdir </> "test.hs"


### PR DESCRIPTION
Currently there are 3 solutions to configure Fourmolu to use its default options:

1. By ensuring no configuration files in its lookup paths

2. By creating a configuration file from `fourmolu --print-defaults`

3. By creating a configuration file with at least one option e.g. `indentation: 4`

The first solution will fail if there's a configuration file somewhere, e.g. when `~/.config/fourmolu.yaml` exists but project's `./fourmolu.yaml` does not, the 2nd and the 3rd implies the project uses non default options.

This patch expands the solutions with creating an empty configuration file.

I'm particularly interested in this because the haskell-language-server test for Fourmolu will fail if the host machine has non default options in their `~/.config/fourmolu.yaml`.
